### PR TITLE
feat: shared public site nav/footer, compliance additions, new pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -14,30 +14,8 @@
 <body>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav scrolled" id="nav">
-  <div class="nav-inner">
-    <a href="index.html" class="nav-logo"><img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" /><span class="nav-logo-text">Vertex Metals</span></a>
-    <ul class="nav-links" role="list">
-      <li><a href="products.html">Products</a></li>
-      <li><a href="industries.html">Sectors</a></li>
-      <li><a href="sustainability.html">Sustainability</a></li>
-      <li><a href="about.html" class="active">About</a></li>
-      <li><a href="compliance.html">Compliance</a></li>
-      <li><a href="partners.html">Partners</a></li>
-    </ul>
-    <a href="contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false"><span></span><span></span><span></span></button>
-  </div>
-</nav>
-<div class="nav-mobile" id="nav-mobile">
-  <a href="products.html">Products</a>
-  <a href="industries.html">Sectors</a>
-  <a href="sustainability.html">Sustainability</a>
-  <a href="about.html" class="active">About</a>
-  <a href="compliance.html">Compliance</a>
-  <a href="partners.html">Partners</a>
-  <a href="contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="js/nav.js"></script>
 
 <!-- ═══ PAGE HERO ═════════════════════════════════════════════ -->
 <section class="page-hero bg-dark">
@@ -198,58 +176,7 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="index.html" class="nav-logo"><img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" /><span class="nav-logo-text">Vertex Metals</span></a>
-        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">No 3 Falcon Cliff<br>9–10 Palace Road, Douglas<br>Isle of Man, IM2 4LD</address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4)">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col">
-        <h4>Products &amp; Sectors</h4>
-        <a href="products.html">All Products</a>
-        <a href="products.html#aluminium">Aluminium Alloys</a>
-        <a href="products.html#copper">Copper &amp; Products</a>
-        <a href="products.html#stainless">Stainless Steel</a>
-        <a href="industries.html">Industries We Serve</a>
-      </div>
-      <div class="footer-col">
-        <h4>Company</h4>
-        <a href="about.html">About Us</a>
-        <a href="sustainability.html">Sustainability</a>
-        <a href="compliance.html">Compliance</a>
-        <a href="partners.html">Become a Partner</a>
-        <a href="contact.html">Contact</a>
-      </div>
-      <div class="footer-col">
-        <h4>Legal &amp; Compliance</h4>
-        <a href="compliance.html">AML/KYC Policy</a>
-        <a href="compliance.html#sanctions">Sanctions Policy</a>
-        <a href="compliance.html#cbam">CBAM Readiness</a>
-        <a href="compliance.html#iso">Quality Standards</a>
-      </div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated in the Isle of Man under the Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-</script>
+<div id="site-footer"></div>
+<script src="js/footer.js"></script>
 </body>
 </html>

--- a/compliance.html
+++ b/compliance.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Compliance — Vertex Metals Ltd</title>
-  <meta name="description" content="Vertex Metals Ltd AML/KYC policy, no-cash policy, sanctions screening, and CBAM readiness statement." />
+  <meta name="description" content="Vertex Metals Ltd AML/KYC policy, no-cash policy, sanctions screening, ethics and modern slavery statement, CBAM readiness, and UK REACH compliance." />
   <link rel="stylesheet" href="css/variables.css" />
   <link rel="stylesheet" href="css/base.css" />
   <link rel="stylesheet" href="css/components.css" />
@@ -18,30 +18,8 @@
 <body>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav scrolled" id="nav">
-  <div class="nav-inner">
-    <a href="index.html" class="nav-logo"><img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" /><span class="nav-logo-text">Vertex Metals</span></a>
-    <ul class="nav-links" role="list">
-      <li><a href="products.html">Products</a></li>
-      <li><a href="industries.html">Sectors</a></li>
-      <li><a href="sustainability.html">Sustainability</a></li>
-      <li><a href="about.html">About</a></li>
-      <li><a href="compliance.html" class="active">Compliance</a></li>
-      <li><a href="partners.html">Partners</a></li>
-    </ul>
-    <a href="contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false"><span></span><span></span><span></span></button>
-  </div>
-</nav>
-<div class="nav-mobile" id="nav-mobile">
-  <a href="products.html">Products</a>
-  <a href="industries.html">Sectors</a>
-  <a href="sustainability.html">Sustainability</a>
-  <a href="about.html">About</a>
-  <a href="compliance.html" class="active">Compliance</a>
-  <a href="partners.html">Partners</a>
-  <a href="contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="js/nav.js"></script>
 
 <!-- ═══ PAGE HERO ═════════════════════════════════════════════ -->
 <section class="page-hero bg-dark">
@@ -55,7 +33,9 @@
       <a href="#aml-kyc" style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.1em;text-transform:uppercase;border:1px solid rgba(122,184,212,0.3);color:var(--color-accent);padding:var(--space-2) var(--space-3);border-radius:var(--radius-sm);text-decoration:none;transition:background var(--transition)" onmouseover="this.style.background='rgba(122,184,212,0.1)'" onmouseout="this.style.background='transparent'">AML/KYC</a>
       <a href="#no-cash" style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.1em;text-transform:uppercase;border:1px solid rgba(122,184,212,0.3);color:var(--color-accent);padding:var(--space-2) var(--space-3);border-radius:var(--radius-sm);text-decoration:none;transition:background var(--transition)" onmouseover="this.style.background='rgba(122,184,212,0.1)'" onmouseout="this.style.background='transparent'">No-Cash Policy</a>
       <a href="#sanctions" style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.1em;text-transform:uppercase;border:1px solid rgba(122,184,212,0.3);color:var(--color-accent);padding:var(--space-2) var(--space-3);border-radius:var(--radius-sm);text-decoration:none;transition:background var(--transition)" onmouseover="this.style.background='rgba(122,184,212,0.1)'" onmouseout="this.style.background='transparent'">Sanctions</a>
+      <a href="#ethics" style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.1em;text-transform:uppercase;border:1px solid rgba(122,184,212,0.3);color:var(--color-accent);padding:var(--space-2) var(--space-3);border-radius:var(--radius-sm);text-decoration:none;transition:background var(--transition)" onmouseover="this.style.background='rgba(122,184,212,0.1)'" onmouseout="this.style.background='transparent'">Ethics</a>
       <a href="#cbam" style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.1em;text-transform:uppercase;border:1px solid rgba(122,184,212,0.3);color:var(--color-accent);padding:var(--space-2) var(--space-3);border-radius:var(--radius-sm);text-decoration:none;transition:background var(--transition)" onmouseover="this.style.background='rgba(122,184,212,0.1)'" onmouseout="this.style.background='transparent'">CBAM</a>
+      <a href="#reach" style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.1em;text-transform:uppercase;border:1px solid rgba(122,184,212,0.3);color:var(--color-accent);padding:var(--space-2) var(--space-3);border-radius:var(--radius-sm);text-decoration:none;transition:background var(--transition)" onmouseover="this.style.background='rgba(122,184,212,0.1)'" onmouseout="this.style.background='transparent'">UK REACH</a>
       <a href="#registrations" style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.1em;text-transform:uppercase;border:1px solid rgba(122,184,212,0.3);color:var(--color-accent);padding:var(--space-2) var(--space-3);border-radius:var(--radius-sm);text-decoration:none;transition:background var(--transition)" onmouseover="this.style.background='rgba(122,184,212,0.1)'" onmouseout="this.style.background='transparent'">Registrations</a>
       <a href="#iso" style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.1em;text-transform:uppercase;border:1px solid rgba(122,184,212,0.3);color:var(--color-accent);padding:var(--space-2) var(--space-3);border-radius:var(--radius-sm);text-decoration:none;transition:background var(--transition)" onmouseover="this.style.background='rgba(122,184,212,0.1)'" onmouseout="this.style.background='transparent'">Quality Standards</a>
     </div>
@@ -131,6 +111,25 @@
         </div>
       </div>
 
+      <!-- Ethics & Modern Slavery -->
+      <div class="compliance-section" id="ethics">
+        <div style="display:flex;align-items:flex-start;gap:var(--space-4);margin-bottom:var(--space-6)">
+          <div style="width:40px;height:40px;background:var(--color-primary);border-radius:var(--radius);display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:4px">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"/><path d="M5 7l-3 7a3 3 0 0 0 6 0z"/><path d="M19 7l-3 7a3 3 0 0 0 6 0z"/><path d="M5 7h14"/><path d="M9 21h6"/></svg>
+          </div>
+          <div>
+            <h2 style="margin-bottom:var(--space-2)">Ethics &amp; Modern Slavery</h2>
+            <div class="divider-steel"></div>
+          </div>
+        </div>
+        <div style="padding-left:56px">
+          <p style="margin-bottom:var(--space-4)">Vertex Metals Ltd is committed to conducting its business ethically and with respect for human rights throughout its global supply chain.</p>
+          <p style="margin-bottom:var(--space-4)">All suppliers are assessed for modern slavery, forced labour, child labour, and human trafficking risk as part of onboarding and ongoing review, in line with the UK Modern Slavery Act 2015. This sits alongside our AML/KYC and sanctions screening and forms part of the wider supplier risk assessment carried out before any trade relationship is established.</p>
+          <p style="margin-bottom:var(--space-4)">Where a supplier is located in, or sources from, a higher-risk jurisdiction or sector, enhanced due diligence is applied, including review of labour practices, working conditions, and any relevant third-party certifications held.</p>
+          <p>Vertex Metals does not knowingly trade with any counterparty found to be engaged in modern slavery, forced labour, or other serious human rights abuses, and reserves the right to terminate any relationship where such practices are identified.</p>
+        </div>
+      </div>
+
       <!-- CBAM -->
       <div class="compliance-section" id="cbam">
         <div style="display:flex;align-items:flex-start;gap:var(--space-4);margin-bottom:var(--space-6)">
@@ -147,6 +146,24 @@
           <p style="margin-bottom:var(--space-4)">Vertex Metals is actively preparing for CBAM implementation. This includes engaging with Indian suppliers to collect installation-level carbon intensity data (tCO₂e per tonne of product), building internal tracking and reporting systems, and monitoring HMRC guidance as it is published.</p>
           <p style="margin-bottom:var(--space-4)">Buyers who may be affected by CBAM obligations are encouraged to raise this with us at the enquiry stage. We are committed to providing the data and documentation necessary to support your CBAM reporting requirements. Vertex Metals must register with HMRC as an authorised declarant before 1 January 2027.</p>
           <p>For specific enquiries about CBAM documentation or carbon intensity data, contact: <a href="mailto:sales@vertexmetalsltd.com" style="color:var(--color-accent)">sales@vertexmetalsltd.com</a></p>
+        </div>
+      </div>
+
+      <!-- UK REACH -->
+      <div class="compliance-section" id="reach">
+        <div style="display:flex;align-items:flex-start;gap:var(--space-4);margin-bottom:var(--space-6)">
+          <div style="width:40px;height:40px;background:var(--color-primary);border-radius:var(--radius);display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:4px">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3h6"/><path d="M10 3v6.5L4.5 19a1 1 0 0 0 .87 1.5h13.26a1 1 0 0 0 .87-1.5L14 9.5V3"/></svg>
+          </div>
+          <div>
+            <h2 style="margin-bottom:var(--space-2)">UK REACH</h2>
+            <div class="divider-steel"></div>
+          </div>
+        </div>
+        <div style="padding-left:56px">
+          <p style="margin-bottom:var(--space-4)">Vertex Metals Ltd is not itself a registrant under UK REACH (the retained regulation governing the Registration, Evaluation, Authorisation and Restriction of Chemicals as it applies in Great Britain). As a trading intermediary, product-level REACH registration and restriction obligations sit with the manufacturer, importer of record, or downstream user, as applicable to the specific trade.</p>
+          <p style="margin-bottom:var(--space-4)">We ensure that any product we supply or import into the UK is checked against applicable UK REACH substance restrictions — including Substances of Very High Concern (SVHC), Annex XIV authorisation requirements, and Annex XVII restrictions — prior to trade. Where a product involves a regulated or restricted substance, this is flagged and reviewed as part of our product qualification process.</p>
+          <p>We require that customers importing goods through Vertex Metals either hold their own UK REACH registration, or have appointed a UK Only Representative (OR) to hold registration on their behalf, before goods are supplied. Buyers unsure of their obligations under UK REACH are welcome to contact us to discuss what is required for a specific product.</p>
         </div>
       </div>
 
@@ -236,58 +253,7 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="index.html" class="nav-logo"><img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" /><span class="nav-logo-text">Vertex Metals</span></a>
-        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">No 3 Falcon Cliff<br>9–10 Palace Road, Douglas<br>Isle of Man, IM2 4LD</address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4)">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col">
-        <h4>Products &amp; Sectors</h4>
-        <a href="products.html">All Products</a>
-        <a href="products.html#aluminium">Aluminium Alloys</a>
-        <a href="products.html#copper">Copper &amp; Products</a>
-        <a href="products.html#stainless">Stainless Steel</a>
-        <a href="industries.html">Industries We Serve</a>
-      </div>
-      <div class="footer-col">
-        <h4>Company</h4>
-        <a href="about.html">About Us</a>
-        <a href="sustainability.html">Sustainability</a>
-        <a href="compliance.html">Compliance</a>
-        <a href="partners.html">Become a Partner</a>
-        <a href="contact.html">Contact</a>
-      </div>
-      <div class="footer-col">
-        <h4>Legal &amp; Compliance</h4>
-        <a href="compliance.html">AML/KYC Policy</a>
-        <a href="compliance.html#sanctions">Sanctions Policy</a>
-        <a href="compliance.html#cbam">CBAM Readiness</a>
-        <a href="compliance.html#iso">Quality Standards</a>
-      </div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated under the Isle of Man Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-</script>
+<div id="site-footer"></div>
+<script src="js/footer.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -16,30 +16,8 @@
 <body>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav scrolled" id="nav">
-  <div class="nav-inner">
-    <a href="index.html" class="nav-logo"><img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" /><span class="nav-logo-text">Vertex Metals</span></a>
-    <ul class="nav-links" role="list">
-      <li><a href="products.html">Products</a></li>
-      <li><a href="industries.html">Sectors</a></li>
-      <li><a href="sustainability.html">Sustainability</a></li>
-      <li><a href="about.html">About</a></li>
-      <li><a href="compliance.html">Compliance</a></li>
-      <li><a href="partners.html">Partners</a></li>
-    </ul>
-    <a href="contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false"><span></span><span></span><span></span></button>
-  </div>
-</nav>
-<div class="nav-mobile" id="nav-mobile">
-  <a href="products.html">Products</a>
-  <a href="industries.html">Sectors</a>
-  <a href="sustainability.html">Sustainability</a>
-  <a href="about.html">About</a>
-  <a href="compliance.html">Compliance</a>
-  <a href="partners.html">Partners</a>
-  <a href="contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="js/nav.js"></script>
 
 <!-- ═══ PAGE HERO ═════════════════════════════════════════════ -->
 <section class="page-hero bg-dark">
@@ -191,63 +169,12 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="index.html" class="nav-logo"><img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" /><span class="nav-logo-text">Vertex Metals</span></a>
-        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">No 3 Falcon Cliff<br>9–10 Palace Road, Douglas<br>Isle of Man, IM2 4LD</address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4)">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col">
-        <h4>Products &amp; Sectors</h4>
-        <a href="products.html">All Products</a>
-        <a href="products.html#aluminium">Aluminium Alloys</a>
-        <a href="products.html#copper">Copper &amp; Products</a>
-        <a href="products.html#stainless">Stainless Steel</a>
-        <a href="industries.html">Industries We Serve</a>
-      </div>
-      <div class="footer-col">
-        <h4>Company</h4>
-        <a href="about.html">About Us</a>
-        <a href="sustainability.html">Sustainability</a>
-        <a href="compliance.html">Compliance</a>
-        <a href="partners.html">Become a Partner</a>
-        <a href="contact.html">Contact</a>
-      </div>
-      <div class="footer-col">
-        <h4>Legal &amp; Compliance</h4>
-        <a href="compliance.html">AML/KYC Policy</a>
-        <a href="compliance.html#sanctions">Sanctions Policy</a>
-        <a href="compliance.html#cbam">CBAM Readiness</a>
-        <a href="compliance.html#iso">Quality Standards</a>
-      </div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated under the Isle of Man Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
+<div id="site-footer"></div>
+<script src="js/footer.js"></script>
 
 <script src="js/supabase-client.js"></script>
 <script src="js/contact-form.js"></script>
 <script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-
-  // Nav hamburger
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-
   // Pre-select family from URL query param (?product=mild-steel etc.)
   const _productSlugMap = {
     'aluminium-alloy-core-wire': 'Aluminium Products',
@@ -257,6 +184,7 @@
     'mild-steel':                'Mild Steel',
     'other-metals':              'Other Metals & Alloys',
     'critical-minerals':         'Critical Minerals & Concentrates',
+    'antimony':                  'Antimony',
   };
   const _preselect = _productSlugMap[new URLSearchParams(window.location.search).get('product')];
   if (_preselect) window._preselectFamily = _preselect;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -14,37 +14,8 @@
 <body>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav" id="nav">
-  <div class="nav-inner">
-    <a href="index.html" class="nav-logo" aria-label="Vertex Metals home">
-      <img src="assets/images/logo/vertex-logo-transparent.png" alt="Vertex Metals" />
-      <span class="nav-logo-text">Vertex Metals</span>
-    </a>
-    <ul class="nav-links" role="list">
-      <li><a href="products.html">Products</a></li>
-      <li><a href="industries.html">Sectors</a></li>
-      <li><a href="sustainability.html">Sustainability</a></li>
-      <li><a href="about.html">About</a></li>
-      <li><a href="compliance.html">Compliance</a></li>
-      <li><a href="partners.html">Partners</a></li>
-    </ul>
-    <a href="contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-  </div>
-</nav>
-
-<!-- Mobile nav -->
-<div class="nav-mobile" id="nav-mobile" role="navigation" aria-label="Mobile navigation">
-  <a href="products.html">Products</a>
-  <a href="industries.html">Sectors</a>
-  <a href="sustainability.html">Sustainability</a>
-  <a href="about.html">About</a>
-  <a href="compliance.html">Compliance</a>
-  <a href="partners.html">Partners</a>
-  <a href="contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="js/nav.js"></script>
 
 <!-- ═══ HERO — VIDEO BANNER ══════════════════════════════════ -->
 <section class="hero-video" aria-label="Hero">
@@ -54,6 +25,11 @@
   </video>
 
   <div class="hero-video-overlay"></div>
+
+  <a href="products/antimony.html" style="position:absolute;top:calc(var(--nav-height) + var(--space-6));right:var(--space-6);z-index:5;max-width:calc(100% - var(--space-8));display:inline-flex;align-items:center;gap:var(--space-3);text-decoration:none;background:var(--color-accent);color:var(--color-primary);padding:var(--space-2) var(--space-4) var(--space-2) var(--space-2);border-radius:var(--radius-sm);box-shadow:0 4px 16px rgba(0,0,0,0.25);transition:background var(--transition)" onmouseover="this.style.background='var(--color-accent-light)'" onmouseout="this.style.background='var(--color-accent)'">
+    <span style="font-family:var(--font-display);font-size:10px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;background:var(--color-primary);color:var(--color-accent);padding:3px 9px;border-radius:9999px;flex-shrink:0">New</span>
+    <span style="font-family:var(--font-display);font-size:var(--text-sm);font-weight:600">Antimony now available — metallic, Grade II/B →</span>
+  </a>
 
   <div class="container hero-video-content">
     <span class="section-label">Vertex Metals Ltd</span>
@@ -333,71 +309,7 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="index.html" class="nav-logo">
-          <img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-          <span class="nav-logo-text">Vertex Metals</span>
-        </a>
-        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">
-            No 3 Falcon Cliff<br>
-            9–10 Palace Road, Douglas<br>
-            Isle of Man, IM2 4LD
-          </address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4);transition:color var(--transition)" onmouseover="this.style.color='var(--color-accent)'" onmouseout="this.style.color='rgba(255,255,255,0.4)'">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col">
-        <h4>Products &amp; Sectors</h4>
-        <a href="products.html">All Products</a>
-        <a href="products.html#aluminium">Aluminium Alloys</a>
-        <a href="products.html#copper">Copper &amp; Products</a>
-        <a href="products.html#stainless">Stainless Steel</a>
-        <a href="industries.html">Industries We Serve</a>
-      </div>
-      <div class="footer-col">
-        <h4>Company</h4>
-        <a href="about.html">About Us</a>
-        <a href="sustainability.html">Sustainability</a>
-        <a href="compliance.html">Compliance</a>
-        <a href="partners.html">Become a Partner</a>
-        <a href="contact.html">Contact</a>
-      </div>
-      <div class="footer-col">
-        <h4>Legal &amp; Compliance</h4>
-        <a href="compliance.html">AML/KYC Policy</a>
-        <a href="compliance.html#sanctions">Sanctions Policy</a>
-        <a href="compliance.html#cbam">CBAM Readiness</a>
-        <a href="compliance.html#iso">Quality Standards</a>
-      </div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated under the Isle of Man Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-
-  const nav = document.getElementById('nav');
-  window.addEventListener('scroll', () => {
-    nav.classList.toggle('scrolled', window.scrollY > 24);
-  }, { passive: true });
-
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-</script>
+<div id="site-footer"></div>
+<script src="js/footer.js"></script>
 </body>
 </html>

--- a/industries.html
+++ b/industries.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -14,35 +14,8 @@
 <body>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav scrolled" id="nav">
-  <div class="nav-inner">
-    <a href="index.html" class="nav-logo" aria-label="Vertex Metals home">
-      <img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-      <span class="nav-logo-text">Vertex Metals</span>
-    </a>
-    <ul class="nav-links" role="list">
-      <li><a href="products.html">Products</a></li>
-      <li><a href="industries.html" class="active">Sectors</a></li>
-      <li><a href="sustainability.html">Sustainability</a></li>
-      <li><a href="about.html">About</a></li>
-      <li><a href="compliance.html">Compliance</a></li>
-      <li><a href="partners.html">Partners</a></li>
-    </ul>
-    <a href="contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-  </div>
-</nav>
-<div class="nav-mobile" id="nav-mobile">
-  <a href="products.html">Products</a>
-  <a href="industries.html" class="active">Sectors</a>
-  <a href="sustainability.html">Sustainability</a>
-  <a href="about.html">About</a>
-  <a href="compliance.html">Compliance</a>
-  <a href="partners.html">Partners</a>
-  <a href="contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="js/nav.js"></script>
 
 <!-- ═══ PAGE HERO WITH VIDEO ══════════════════════════════════ -->
 <section style="position:relative;overflow:hidden;min-height:540px;display:flex;align-items:center;margin-top:var(--nav-height)">
@@ -286,61 +259,7 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="index.html" class="nav-logo">
-          <img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-          <span class="nav-logo-text">Vertex Metals</span>
-        </a>
-        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">No 3 Falcon Cliff<br>9–10 Palace Road, Douglas<br>Isle of Man, IM2 4LD</address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4)">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col">
-        <h4>Products &amp; Sectors</h4>
-        <a href="products.html">All Products</a>
-        <a href="products.html#aluminium">Aluminium Alloys</a>
-        <a href="products.html#copper">Copper &amp; Products</a>
-        <a href="products.html#stainless">Stainless Steel</a>
-        <a href="industries.html">Industries We Serve</a>
-      </div>
-      <div class="footer-col">
-        <h4>Company</h4>
-        <a href="about.html">About Us</a>
-        <a href="sustainability.html">Sustainability</a>
-        <a href="compliance.html">Compliance</a>
-        <a href="partners.html">Become a Partner</a>
-        <a href="contact.html">Contact</a>
-      </div>
-      <div class="footer-col">
-        <h4>Legal &amp; Compliance</h4>
-        <a href="compliance.html">AML/KYC Policy</a>
-        <a href="compliance.html#sanctions">Sanctions Policy</a>
-        <a href="compliance.html#cbam">CBAM Readiness</a>
-        <a href="compliance.html#iso">Quality Standards</a>
-      </div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated under the Isle of Man Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-</script>
+<div id="site-footer"></div>
+<script src="js/footer.js"></script>
 </body>
 </html>

--- a/js/footer.js
+++ b/js/footer.js
@@ -1,0 +1,82 @@
+/**
+ * Vertex Metals — Public Site Footer
+ *
+ * Single source of truth for the footer across all public pages.
+ * Generates the footer HTML and injects it into #site-footer.
+ * Relative path depth is detected automatically from
+ * window.location.pathname — no per-page hardcoding required.
+ *
+ * To use on any public page:
+ *   1. Replace the <footer class="footer">...</footer> block with a single
+ *      empty placeholder:
+ *        <div id="site-footer"></div>
+ *   2. Add this script right after the placeholder:
+ *        <script src="[path-to-root]js/footer.js"></script>
+ *
+ * Editing footer content/links: edit this file only.
+ */
+(function () {
+
+  const parts = window.location.pathname.split('/').filter(Boolean);
+  const depth = Math.max(parts.length - 1, 0);
+  const p     = '../'.repeat(depth); // prefix to reach site root
+
+  const html = `
+<footer class="footer">
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-brand">
+        <a href="${p}index.html" class="nav-logo">
+          <img src="${p}assets/images/logo/vertex-logo-transparent.png" alt="Vertex Metals" />
+          <span class="nav-logo-text">Vertex Metals</span>
+        </a>
+        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
+        <div style="margin-top:var(--space-6)">
+          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">
+            No 3 Falcon Cliff<br>
+            9–10 Palace Road, Douglas<br>
+            Isle of Man, IM2 4LD
+          </address>
+          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4);transition:color var(--transition)" onmouseover="this.style.color='var(--color-accent)'" onmouseout="this.style.color='rgba(255,255,255,0.4)'">sales@vertexmetalsltd.com</a>
+        </div>
+      </div>
+      <div class="footer-col">
+        <h4>Products &amp; Sectors</h4>
+        <a href="${p}products.html">All Products</a>
+        <a href="${p}products.html#aluminium">Aluminium Alloys</a>
+        <a href="${p}products.html#copper">Copper &amp; Products</a>
+        <a href="${p}products.html#stainless">Stainless Steel</a>
+        <a href="${p}industries.html">Industries We Serve</a>
+      </div>
+      <div class="footer-col">
+        <h4>Company</h4>
+        <a href="${p}about.html">About Us</a>
+        <a href="${p}sustainability.html">Sustainability</a>
+        <a href="${p}compliance.html">Compliance</a>
+        <a href="${p}partners.html">Become a Partner</a>
+        <a href="${p}contact.html">Contact</a>
+      </div>
+      <div class="footer-col">
+        <h4>Legal &amp; Compliance</h4>
+        <a href="${p}compliance.html">AML/KYC Policy</a>
+        <a href="${p}compliance.html#sanctions">Sanctions Policy</a>
+        <a href="${p}compliance.html#ethics">Ethics &amp; Modern Slavery</a>
+        <a href="${p}compliance.html#cbam">CBAM Readiness</a>
+        <a href="${p}compliance.html#reach">UK REACH</a>
+        <a href="${p}compliance.html#iso">Quality Standards</a>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
+      <p>Incorporated under the Isle of Man Companies Act 1931</p>
+      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
+    </div>
+  </div>
+</footer>`;
+
+  const mount = document.getElementById('site-footer');
+  if (!mount) return;
+  mount.outerHTML = html;
+
+  document.getElementById('year').textContent = new Date().getFullYear();
+})();

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,0 +1,89 @@
+/**
+ * Vertex Metals — Public Site Navigation
+ *
+ * Single source of truth for the top nav across all public pages.
+ * Generates the nav + mobile nav HTML and injects it into #site-nav.
+ * Active link and relative path depth are both detected automatically
+ * from window.location.pathname — no per-page hardcoding required.
+ *
+ * To use on any public page:
+ *   1. Replace the <nav>...</nav> and following <div class="nav-mobile">
+ *      block with a single empty placeholder:
+ *        <div id="site-nav"></div>
+ *   2. Add this script right after the placeholder:
+ *        <script src="[path-to-root]js/nav.js"></script>
+ *
+ * Adding/removing a nav link: edit LINKS below only.
+ */
+(function () {
+
+  const LINKS = [
+    { href: 'products.html',       label: 'Products' },
+    { href: 'industries.html',     label: 'Sectors' },
+    { href: 'sustainability.html', label: 'Sustainability' },
+    { href: 'about.html',          label: 'About' },
+    { href: 'compliance.html',     label: 'Compliance' },
+    { href: 'partners.html',       label: 'Partners' },
+  ];
+
+  // ── Path depth ────────────────────────────────────────────────────────────
+  // Work out how many directory levels the current page sits below the site
+  // root, so all links and asset paths use the correct relative prefix.
+  const parts = window.location.pathname.split('/').filter(Boolean);
+  const file  = parts[parts.length - 1] || 'index.html';
+  const depth = Math.max(parts.length - 1, 0);
+  const p     = '../'.repeat(depth); // prefix to reach site root
+
+  // Product detail pages (products/*.html) don't have their own nav entry —
+  // they belong under "Products".
+  const activeHref = parts[0] === 'products' && parts.length > 1 ? 'products.html' : file;
+
+  const navLinks = LINKS.map(l =>
+    `<li><a href="${p}${l.href}"${l.href === activeHref ? ' class="active"' : ''}>${l.label}</a></li>`
+  ).join('\n      ');
+
+  const mobileLinks = LINKS.map(l => `<a href="${p}${l.href}">${l.label}</a>`).join('\n  ');
+
+  const html = `
+<nav class="nav" id="nav">
+  <div class="nav-inner">
+    <a href="${p}index.html" class="nav-logo" aria-label="Vertex Metals home">
+      <img src="${p}assets/images/logo/vertex-logo-transparent.png" alt="Vertex Metals" />
+      <span class="nav-logo-text">Vertex Metals</span>
+    </a>
+    <ul class="nav-links" role="list">
+      ${navLinks}
+    </ul>
+    <a href="${p}contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
+    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
+      <span></span><span></span><span></span>
+    </button>
+  </div>
+</nav>
+<div class="nav-mobile" id="nav-mobile" role="navigation" aria-label="Mobile navigation">
+  ${mobileLinks}
+  <a href="${p}contact.html" class="btn btn-primary">Submit Enquiry</a>
+</div>`;
+
+  const mount = document.getElementById('site-nav');
+  if (!mount) return;
+  mount.outerHTML = html;
+
+  // ── Behaviour ─────────────────────────────────────────────────────────────
+  // Every page has a dark hero directly under the nav (hero-video on the
+  // homepage, page-hero elsewhere), so the nav starts transparent over it and
+  // solidifies once the page scrolls past the hero — universal, not just home.
+  const nav = document.getElementById('nav');
+  window.addEventListener('scroll', () => {
+    nav.classList.toggle('scrolled', window.scrollY > 24);
+  }, { passive: true });
+  nav.classList.toggle('scrolled', window.scrollY > 24); // correct state on load if not at top (e.g. back-navigation)
+
+  const hamburger = document.getElementById('hamburger');
+  const navMobile = document.getElementById('nav-mobile');
+  hamburger.addEventListener('click', () => {
+    const open = navMobile.classList.toggle('open');
+    hamburger.classList.toggle('open', open);
+    hamburger.setAttribute('aria-expanded', String(open));
+  });
+})();

--- a/partners.html
+++ b/partners.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -15,35 +15,8 @@
 <body>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav scrolled" id="nav">
-  <div class="nav-inner">
-    <a href="index.html" class="nav-logo" aria-label="Vertex Metals home">
-      <img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-      <span class="nav-logo-text">Vertex Metals</span>
-    </a>
-    <ul class="nav-links" role="list">
-      <li><a href="products.html">Products</a></li>
-      <li><a href="industries.html">Sectors</a></li>
-      <li><a href="sustainability.html">Sustainability</a></li>
-      <li><a href="about.html">About</a></li>
-      <li><a href="compliance.html">Compliance</a></li>
-      <li><a href="partners.html" class="active">Partners</a></li>
-    </ul>
-    <a href="contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-  </div>
-</nav>
-<div class="nav-mobile" id="nav-mobile">
-  <a href="products.html">Products</a>
-  <a href="industries.html">Sectors</a>
-  <a href="sustainability.html">Sustainability</a>
-  <a href="about.html">About</a>
-  <a href="compliance.html">Compliance</a>
-  <a href="partners.html" class="active">Partners</a>
-  <a href="contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="js/nav.js"></script>
 
 <!-- ═══ HERO — IMAGE BANNER ═══════════════════════════════════ -->
 <section class="hero-video" aria-label="Partner hero">
@@ -357,69 +330,11 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="index.html" class="nav-logo">
-          <img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-          <span class="nav-logo-text">Vertex Metals</span>
-        </a>
-        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">No 3 Falcon Cliff<br>9–10 Palace Road, Douglas<br>Isle of Man, IM2 4LD</address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4)">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col">
-        <h4>Products &amp; Sectors</h4>
-        <a href="products.html">All Products</a>
-        <a href="products.html#aluminium">Aluminium Alloys</a>
-        <a href="products.html#copper">Copper &amp; Products</a>
-        <a href="products.html#stainless">Stainless Steel</a>
-        <a href="industries.html">Industries We Serve</a>
-      </div>
-      <div class="footer-col">
-        <h4>Company</h4>
-        <a href="about.html">About Us</a>
-        <a href="sustainability.html">Sustainability</a>
-        <a href="compliance.html">Compliance</a>
-        <a href="partners.html">Become a Partner</a>
-        <a href="contact.html">Contact</a>
-      </div>
-      <div class="footer-col">
-        <h4>Legal &amp; Compliance</h4>
-        <a href="compliance.html">AML/KYC Policy</a>
-        <a href="compliance.html#sanctions">Sanctions Policy</a>
-        <a href="compliance.html#cbam">CBAM Readiness</a>
-        <a href="compliance.html#iso">Quality Standards</a>
-      </div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated under the Isle of Man Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
+<div id="site-footer"></div>
+<script src="js/footer.js"></script>
 
 <script src="js/supabase-client.js"></script>
 <script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-
-  const nav = document.getElementById('nav');
-  window.addEventListener('scroll', () => {
-    nav.classList.toggle('scrolled', window.scrollY > 24);
-  }, { passive: true });
-
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-
   // Netlify Forms — AJAX submission so the page doesn't reload
   const partnerForm = document.getElementById('partner-form');
   if (partnerForm) {

--- a/products.html
+++ b/products.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -14,38 +14,11 @@
 <body>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav scrolled" id="nav">
-  <div class="nav-inner">
-    <a href="index.html" class="nav-logo" aria-label="Vertex Metals home">
-      <img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-      <span class="nav-logo-text">Vertex Metals</span>
-    </a>
-    <ul class="nav-links" role="list">
-      <li><a href="products.html" class="active">Products</a></li>
-      <li><a href="industries.html">Sectors</a></li>
-      <li><a href="sustainability.html">Sustainability</a></li>
-      <li><a href="about.html">About</a></li>
-      <li><a href="compliance.html">Compliance</a></li>
-      <li><a href="partners.html">Partners</a></li>
-    </ul>
-    <a href="contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-  </div>
-</nav>
-<div class="nav-mobile" id="nav-mobile">
-  <a href="products.html" class="active">Products</a>
-  <a href="industries.html">Sectors</a>
-  <a href="sustainability.html">Sustainability</a>
-  <a href="about.html">About</a>
-  <a href="compliance.html">Compliance</a>
-  <a href="partners.html">Partners</a>
-  <a href="contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="js/nav.js"></script>
 
 <!-- ═══ PAGE VIDEO BANNER ══════════════════════════════════════ -->
-<div class="page-video-banner" style="margin-top:var(--nav-height);position:relative;overflow:hidden">
+<div class="page-video-banner">
   <video autoplay muted loop playsinline style="width:100%;height:100%;object-fit:cover;object-position:center 40%;display:block;position:absolute;top:0;left:0">
     <source src="assets/video/products-steel.mp4" type="video/mp4">
   </video>
@@ -275,6 +248,7 @@
 
           <p style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--color-text-muted);margin-bottom:var(--space-3)">Materials Available</p>
           <ul class="product-forms-list">
+            <li>Antimony (metallic &amp; concentrate, various specifications) — <a href="products/antimony.html" style="color:var(--color-accent)">new supply available →</a></li>
             <li>Brass</li>
             <li>Bronze</li>
             <li>Tool steel</li>
@@ -342,61 +316,7 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="index.html" class="nav-logo">
-          <img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-          <span class="nav-logo-text">Vertex Metals</span>
-        </a>
-        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">No 3 Falcon Cliff<br>9–10 Palace Road, Douglas<br>Isle of Man, IM2 4LD</address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4)">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col">
-        <h4>Products &amp; Sectors</h4>
-        <a href="products.html">All Products</a>
-        <a href="products.html#aluminium">Aluminium Alloys</a>
-        <a href="products.html#copper">Copper &amp; Products</a>
-        <a href="products.html#stainless">Stainless Steel</a>
-        <a href="industries.html">Industries We Serve</a>
-      </div>
-      <div class="footer-col">
-        <h4>Company</h4>
-        <a href="about.html">About Us</a>
-        <a href="sustainability.html">Sustainability</a>
-        <a href="compliance.html">Compliance</a>
-        <a href="partners.html">Become a Partner</a>
-        <a href="contact.html">Contact</a>
-      </div>
-      <div class="footer-col">
-        <h4>Legal &amp; Compliance</h4>
-        <a href="compliance.html">AML/KYC Policy</a>
-        <a href="compliance.html#sanctions">Sanctions Policy</a>
-        <a href="compliance.html#cbam">CBAM Readiness</a>
-        <a href="compliance.html#iso">Quality Standards</a>
-      </div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated under the Isle of Man Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-</script>
+<div id="site-footer"></div>
+<script src="js/footer.js"></script>
 </body>
 </html>

--- a/products/aluminium-alloy-core-wire.html
+++ b/products/aluminium-alloy-core-wire.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -14,31 +14,8 @@
 <body>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav scrolled" id="nav">
-  <div class="nav-inner">
-    <a href="../index.html" class="nav-logo" aria-label="Vertex Metals home">
-      <img src="../assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-      <span class="nav-logo-text">Vertex Metals</span>
-    </a>
-    <ul class="nav-links" role="list">
-      <li><a href="../products.html" class="active">Products</a></li>
-      <li><a href="../about.html">About</a></li>
-      <li><a href="../compliance.html">Compliance</a></li>
-      <li><a href="../contact.html">Contact</a></li>
-    </ul>
-    <a href="../contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-  </div>
-</nav>
-<div class="nav-mobile" id="nav-mobile">
-  <a href="../products.html">Products</a>
-  <a href="../about.html">About</a>
-  <a href="../compliance.html">Compliance</a>
-  <a href="../contact.html">Contact</a>
-  <a href="../contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="../js/nav.js"></script>
 
 <!-- ═══ PAGE HERO ═════════════════════════════════════════════ -->
 <section class="page-hero bg-dark">
@@ -175,41 +152,7 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="../index.html" class="nav-logo">
-          <img src="../assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-          <span class="nav-logo-text">Vertex Metals</span>
-        </a>
-        <p>Isle of Man commodity trading intermediary.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">No 3 Falcon Cliff<br>9–10 Palace Road, Douglas<br>Isle of Man, IM2 4LD</address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4)">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col"><h4>Company</h4><a href="../about.html">About Us</a><a href="../compliance.html">Compliance</a><a href="../contact.html">Contact</a></div>
-      <div class="footer-col"><h4>Products</h4><a href="aluminium-alloy-core-wire.html">Aluminium Alloy Core Wire</a><a href="../products.html">All Products</a></div>
-      <div class="footer-col"><h4>Legal</h4><a href="../compliance.html">AML/KYC Policy</a><a href="../compliance.html#sanctions">Sanctions Policy</a><a href="../compliance.html#cbam">CBAM Readiness</a></div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated in the Isle of Man under the Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-</script>
+<div id="site-footer"></div>
+<script src="../js/footer.js"></script>
 </body>
 </html>

--- a/products/antimony.html
+++ b/products/antimony.html
@@ -4,8 +4,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Copper &amp; Copper Products — Vertex Metals Ltd</title>
-  <meta name="description" content="Copper plates, rods, wire, tube, sheets, and pipes sourced from India and the Asia-Pacific for UK industrial buyers. Vertex Metals Ltd." />
+  <title>Antimony — Vertex Metals Ltd</title>
+  <meta name="description" content="Metallic antimony (Grade II / Grade B) sourced from South America — new qualified supply capacity of 12+ MT per month. Vertex Metals Ltd." />
   <link rel="stylesheet" href="../css/variables.css" />
   <link rel="stylesheet" href="../css/base.css" />
   <link rel="stylesheet" href="../css/components.css" />
@@ -21,13 +21,14 @@
 <section class="page-hero bg-dark">
   <div class="container" style="position:relative;z-index:1">
     <a href="../products.html" style="display:inline-flex;align-items:center;gap:var(--space-2);font-family:var(--font-display);font-size:var(--text-xs);font-weight:500;letter-spacing:0.15em;text-transform:uppercase;color:rgba(122,184,212,0.6);margin-bottom:var(--space-6);text-decoration:none;transition:color var(--transition)" onmouseover="this.style.color='var(--color-accent)'" onmouseout="this.style.color='rgba(122,184,212,0.6)'">← All Products</a>
-    <span class="section-label">India &amp; Asia-Pacific</span>
-    <h1 class="text-white" style="max-width:700px;margin-bottom:var(--space-4)">Copper &amp; Copper Products</h1>
+    <span class="section-label">New Supply — South American Origin</span>
+    <h1 class="text-white" style="max-width:700px;margin-bottom:var(--space-4)">Antimony</h1>
     <div class="divider-steel"></div>
     <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4)">
-      <span class="badge badge-neutral">On Enquiry</span>
+      <span class="badge badge-success">New Supply Available</span>
+      <span style="font-size:var(--text-sm);color:rgba(255,255,255,0.45)">Origin: South America</span>
     </div>
-    <p style="max-width:640px;color:rgba(255,255,255,0.55);font-size:var(--text-lg)">Copper plates, rods, wire, tube, sheets, and pipes sourced from qualified mills across India and the Asia-Pacific, supplied to UK industrial buyers with full documentation and compliance built in.</p>
+    <p style="max-width:640px;color:rgba(255,255,255,0.55);font-size:var(--text-lg)">Metallic antimony, Grade II or Grade B, from a newly qualified South American source with confirmed monthly capacity of 12 MT or more — supplied under our standard AML/KYC and sanctions screening framework.</p>
   </div>
 </section>
 
@@ -43,15 +44,15 @@
         <div style="margin-bottom:var(--space-12)">
           <h2 style="margin-bottom:var(--space-3)">Overview</h2>
           <div class="divider-steel"></div>
-          <p style="margin-bottom:var(--space-4)">Copper is a critical input for UK electrical manufacturing, grid infrastructure, renewable energy installations, EV charging networks, and telecoms. Vertex Metals sources copper products across all standard grades from qualified mills in India and the Asia-Pacific, delivering directly to UK buyers with full trade documentation.</p>
-          <p style="margin-bottom:var(--space-4)">The UK's energy transition is driving significant growth in copper demand — from grid upgrades and offshore wind interconnects to EV charging infrastructure. We source against buyer specification, ensuring the right grade, form, and certification for each application.</p>
-          <p>All copper products are supplied with mill test reports and certificates of origin. CBAM carbon-intensity data is available for covered materials.</p>
+          <p style="margin-bottom:var(--space-4)">Antimony is a strategically important metal used in flame retardants, lead-acid battery alloys, ammunition, semiconductors, and specialist glass and ceramics manufacture. It is recognised as a critical raw material by the UK, EU, and US, reflecting concentrated global supply and its importance to industrial and defence supply chains.</p>
+          <p style="margin-bottom:var(--space-4)">Vertex Metals has secured access to a newly qualified source of metallic antimony from South America, with confirmed monthly supply capacity of 12 MT or more, available in Grade II or Grade B. This is an active, near-term supply opportunity rather than a forward capability.</p>
+          <p>As with all new supplier relationships, this counterparty is subject to our full AML/KYC, sanctions screening, and ethics due diligence programme before any trade is confirmed.</p>
         </div>
 
-        <!-- UK market context -->
+        <!-- Supply highlight -->
         <div style="background:var(--color-primary);border-radius:var(--radius);padding:var(--space-8);margin-bottom:var(--space-12)">
-          <span class="section-label">UK Market Context</span>
-          <p style="color:rgba(255,255,255,0.6)">UK copper demand is rising sharply, driven by grid infrastructure investment, EV charging rollout, and renewable energy expansion. Procurement teams are under pressure to secure reliable, compliant supply at competitive landed cost. Vertex Metals provides a qualified sourcing route with full AML/KYC and documentation standards built in.</p>
+          <span class="section-label">New Supply Opportunity</span>
+          <p style="color:rgba(255,255,255,0.6)">This is a newly onboarded source, not yet part of our standard active inventory listings. Specific supplier and origin details are treated as commercially confidential and are shared directly with qualified buyers following initial enquiry, in line with our standard practice for new supply relationships. Submit an enquiry below to discuss volumes, specification, and indicative pricing.</p>
         </div>
 
         <!-- Applications -->
@@ -61,35 +62,35 @@
           <div class="grid-2" style="gap:var(--space-3)">
             <div style="display:flex;align-items:flex-start;gap:var(--space-3)">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-top:3px;flex-shrink:0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Power cable manufacture &amp; grid infrastructure</span>
+              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Flame retardants (antimony trioxide)</span>
             </div>
             <div style="display:flex;align-items:flex-start;gap:var(--space-3)">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-top:3px;flex-shrink:0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">EV charging infrastructure</span>
+              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Lead-acid battery alloys</span>
             </div>
             <div style="display:flex;align-items:flex-start;gap:var(--space-3)">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-top:3px;flex-shrink:0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Offshore &amp; onshore wind interconnects</span>
+              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Ammunition &amp; ordnance</span>
             </div>
             <div style="display:flex;align-items:flex-start;gap:var(--space-3)">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-top:3px;flex-shrink:0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Electrical engineering &amp; switchgear</span>
+              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Semiconductors &amp; electronics</span>
             </div>
             <div style="display:flex;align-items:flex-start;gap:var(--space-3)">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-top:3px;flex-shrink:0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Telecoms infrastructure</span>
+              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Glass, ceramics &amp; pigments</span>
             </div>
             <div style="display:flex;align-items:flex-start;gap:var(--space-3)">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-top:3px;flex-shrink:0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Plumbing &amp; HVAC</span>
+              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Plastics stabilisers</span>
             </div>
           </div>
         </div>
 
-        <!-- CBAM note -->
-        <div style="border:1px solid var(--color-warning);background:var(--color-warning-bg);border-radius:var(--radius);padding:var(--space-6)">
-          <p style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--color-warning);margin-bottom:var(--space-2)">UK CBAM Note</p>
-          <p style="font-size:var(--text-sm);color:var(--color-text-secondary)">UK Carbon Border Adjustment Mechanism (CBAM) takes effect 1 January 2027. Copper is within scope. Vertex Metals is building carbon-intensity data (tCO₂e/tonne) for supplier facilities to support buyer CBAM reporting obligations. <a href="../compliance.html#cbam" style="color:var(--color-accent)">Learn more →</a></p>
+        <!-- Confidentiality note -->
+        <div style="border:1px solid var(--color-border);background:var(--color-surface);border-radius:var(--radius);padding:var(--space-6)">
+          <p style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--color-text-muted);margin-bottom:var(--space-2)">Supplier confidentiality</p>
+          <p style="font-size:var(--text-sm);color:var(--color-text-secondary)">Specific supplier and origin information for this opportunity is treated as commercially confidential and shared only with qualified buyers under appropriate terms. All new suppliers undergo full AML/KYC, sanctions screening, and ethics due diligence — including modern slavery risk assessment — before any trade is confirmed. <a href="../compliance.html" style="color:var(--color-accent)">View compliance policy →</a></p>
         </div>
 
       </div>
@@ -99,28 +100,32 @@
 
         <!-- Spec table -->
         <div class="card">
-          <h3 style="font-size:var(--text-lg);margin-bottom:var(--space-4)">Technical Specifications</h3>
+          <h3 style="font-size:var(--text-lg);margin-bottom:var(--space-4)">Specifications</h3>
           <div class="divider-steel"></div>
           <dl>
             <div style="display:flex;flex-direction:column;gap:var(--space-1);padding:var(--space-3) 0;border-bottom:1px solid var(--color-border)">
+              <dt style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--color-text-muted)">Form</dt>
+              <dd style="font-size:var(--text-sm);font-weight:600;color:var(--color-text-primary)">Metallic (ingot)</dd>
+            </div>
+            <div style="display:flex;flex-direction:column;gap:var(--space-1);padding:var(--space-3) 0;border-bottom:1px solid var(--color-border)">
               <dt style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--color-text-muted)">Grades available</dt>
-              <dd style="font-size:var(--text-sm);font-weight:600;color:var(--color-text-primary)">Cu-ETP (C11000), Cu-DHP (C12200), Cu-OF (C10200)</dd>
+              <dd style="font-size:var(--text-sm);font-weight:600;color:var(--color-text-primary)">Grade II, Grade B</dd>
             </div>
             <div style="display:flex;flex-direction:column;gap:var(--space-1);padding:var(--space-3) 0;border-bottom:1px solid var(--color-border)">
-              <dt style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--color-text-muted)">Product forms</dt>
-              <dd style="font-size:var(--text-sm);font-weight:600;color:var(--color-text-primary)">Plates, rods, wire, tube, sheets, pipes</dd>
+              <dt style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--color-text-muted)">Minimum monthly capacity</dt>
+              <dd style="font-size:var(--text-sm);font-weight:600;color:var(--color-text-primary)">12 MT+</dd>
             </div>
             <div style="display:flex;flex-direction:column;gap:var(--space-1);padding:var(--space-3) 0;border-bottom:1px solid var(--color-border)">
-              <dt style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--color-text-muted)">Standard</dt>
-              <dd style="font-size:var(--text-sm);font-weight:600;color:var(--color-text-primary)">BS EN 1172, ASTM B152, ASTM B133</dd>
+              <dt style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--color-text-muted)">Origin</dt>
+              <dd style="font-size:var(--text-sm);font-weight:600;color:var(--color-text-primary)">South America</dd>
             </div>
             <div style="display:flex;flex-direction:column;gap:var(--space-1);padding:var(--space-3) 0;border-bottom:1px solid var(--color-border)">
-              <dt style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--color-text-muted)">Documentation</dt>
-              <dd style="font-size:var(--text-sm);font-weight:600;color:var(--color-text-primary)">Mill test reports, certificate of origin</dd>
+              <dt style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--color-text-muted)">Concentrate</dt>
+              <dd style="font-size:var(--text-sm);font-weight:600;color:var(--color-text-primary)">Also available on enquiry, various specifications</dd>
             </div>
             <div style="display:flex;flex-direction:column;gap:var(--space-1);padding:var(--space-3) 0">
               <dt style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:0.12em;text-transform:uppercase;color:var(--color-text-muted)">Incoterms</dt>
-              <dd style="font-size:var(--text-sm);font-weight:600;color:var(--color-text-primary)">FOB origin port, CIF UK port</dd>
+              <dd style="font-size:var(--text-sm);font-weight:600;color:var(--color-text-primary)">To be confirmed per enquiry</dd>
             </div>
           </dl>
         </div>
@@ -128,8 +133,8 @@
         <!-- Quote CTA -->
         <div class="card-dark">
           <h3 style="color:#fff;margin-bottom:var(--space-3)">Submit Enquiry</h3>
-          <p style="color:rgba(255,255,255,0.45);font-size:var(--text-sm);margin-bottom:var(--space-5)">Submit your specification and we will respond with indicative pricing within one business day.</p>
-          <a href="../contact.html?product=copper" class="btn btn-primary" style="width:100%;justify-content:center">Submit Enquiry →</a>
+          <p style="color:rgba(255,255,255,0.45);font-size:var(--text-sm);margin-bottom:var(--space-5)">Tell us your required volume, grade, and timeline and we will confirm feasibility and indicative pricing.</p>
+          <a href="../contact.html?product=antimony" class="btn btn-primary" style="width:100%;justify-content:center">Submit Enquiry →</a>
         </div>
 
         <!-- Compliance note -->

--- a/products/critical-minerals.html
+++ b/products/critical-minerals.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -14,35 +14,8 @@
 <body>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav scrolled" id="nav">
-  <div class="nav-inner">
-    <a href="../index.html" class="nav-logo" aria-label="Vertex Metals home">
-      <img src="../assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-      <span class="nav-logo-text">Vertex Metals</span>
-    </a>
-    <ul class="nav-links" role="list">
-      <li><a href="../products.html" class="active">Products</a></li>
-      <li><a href="../industries.html">Sectors</a></li>
-      <li><a href="../sustainability.html">Sustainability</a></li>
-      <li><a href="../about.html">About</a></li>
-      <li><a href="../compliance.html">Compliance</a></li>
-      <li><a href="../partners.html">Partners</a></li>
-    </ul>
-    <a href="../contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-  </div>
-</nav>
-<div class="nav-mobile" id="nav-mobile">
-  <a href="../products.html">Products</a>
-  <a href="../industries.html">Sectors</a>
-  <a href="../sustainability.html">Sustainability</a>
-  <a href="../about.html">About</a>
-  <a href="../compliance.html">Compliance</a>
-  <a href="../partners.html">Partners</a>
-  <a href="../contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="../js/nav.js"></script>
 
 <!-- ═══ PAGE HERO ═════════════════════════════════════════════ -->
 <section class="page-hero bg-dark">
@@ -161,41 +134,7 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="../index.html" class="nav-logo">
-          <img src="../assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-          <span class="nav-logo-text">Vertex Metals</span>
-        </a>
-        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">No 3 Falcon Cliff<br>9–10 Palace Road, Douglas<br>Isle of Man, IM2 4LD</address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4)">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col"><h4>Products</h4><a href="../products.html">All Products</a><a href="aluminium-alloy-core-wire.html">Aluminium Core Wire</a><a href="copper-products.html">Copper Products</a><a href="stainless-steel.html">Stainless Steel</a><a href="mild-steel.html">Mild Steel</a></div>
-      <div class="footer-col"><h4>Company</h4><a href="../about.html">About Us</a><a href="../sustainability.html">Sustainability</a><a href="../compliance.html">Compliance</a><a href="../partners.html">Partners</a></div>
-      <div class="footer-col"><h4>Legal</h4><a href="../compliance.html">AML/KYC Policy</a><a href="../compliance.html#sanctions">Sanctions Policy</a><a href="../compliance.html#cbam">CBAM Readiness</a></div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated in the Isle of Man under the Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-</script>
+<div id="site-footer"></div>
+<script src="../js/footer.js"></script>
 </body>
 </html>

--- a/products/mild-steel.html
+++ b/products/mild-steel.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -14,35 +14,8 @@
 <body>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav scrolled" id="nav">
-  <div class="nav-inner">
-    <a href="../index.html" class="nav-logo" aria-label="Vertex Metals home">
-      <img src="../assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-      <span class="nav-logo-text">Vertex Metals</span>
-    </a>
-    <ul class="nav-links" role="list">
-      <li><a href="../products.html" class="active">Products</a></li>
-      <li><a href="../industries.html">Sectors</a></li>
-      <li><a href="../sustainability.html">Sustainability</a></li>
-      <li><a href="../about.html">About</a></li>
-      <li><a href="../compliance.html">Compliance</a></li>
-      <li><a href="../partners.html">Partners</a></li>
-    </ul>
-    <a href="../contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-  </div>
-</nav>
-<div class="nav-mobile" id="nav-mobile">
-  <a href="../products.html">Products</a>
-  <a href="../industries.html">Sectors</a>
-  <a href="../sustainability.html">Sustainability</a>
-  <a href="../about.html">About</a>
-  <a href="../compliance.html">Compliance</a>
-  <a href="../partners.html">Partners</a>
-  <a href="../contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="../js/nav.js"></script>
 
 <!-- ═══ PAGE HERO ═════════════════════════════════════════════ -->
 <section class="page-hero bg-dark">
@@ -170,41 +143,7 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="../index.html" class="nav-logo">
-          <img src="../assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-          <span class="nav-logo-text">Vertex Metals</span>
-        </a>
-        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">No 3 Falcon Cliff<br>9–10 Palace Road, Douglas<br>Isle of Man, IM2 4LD</address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4)">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col"><h4>Products</h4><a href="../products.html">All Products</a><a href="aluminium-alloy-core-wire.html">Aluminium Core Wire</a><a href="copper-products.html">Copper Products</a><a href="stainless-steel.html">Stainless Steel</a><a href="mild-steel.html">Mild Steel</a></div>
-      <div class="footer-col"><h4>Company</h4><a href="../about.html">About Us</a><a href="../sustainability.html">Sustainability</a><a href="../compliance.html">Compliance</a><a href="../partners.html">Partners</a></div>
-      <div class="footer-col"><h4>Legal</h4><a href="../compliance.html">AML/KYC Policy</a><a href="../compliance.html#sanctions">Sanctions Policy</a><a href="../compliance.html#cbam">CBAM Readiness</a></div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated in the Isle of Man under the Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-</script>
+<div id="site-footer"></div>
+<script src="../js/footer.js"></script>
 </body>
 </html>

--- a/products/other-metals.html
+++ b/products/other-metals.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Other Metals &amp; Alloys — Vertex Metals Ltd</title>
-  <meta name="description" content="Brass, bronze, tool steel, bright steel, Inconel and titanium sourced globally for UK industrial buyers on enquiry. Vertex Metals Ltd." />
+  <meta name="description" content="Antimony (metallic and concentrate), brass, bronze, tool steel, bright steel, Inconel and titanium sourced globally for UK industrial buyers on enquiry. Vertex Metals Ltd." />
   <link rel="stylesheet" href="../css/variables.css" />
   <link rel="stylesheet" href="../css/base.css" />
   <link rel="stylesheet" href="../css/components.css" />
@@ -14,35 +14,8 @@
 <body>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav scrolled" id="nav">
-  <div class="nav-inner">
-    <a href="../index.html" class="nav-logo" aria-label="Vertex Metals home">
-      <img src="../assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-      <span class="nav-logo-text">Vertex Metals</span>
-    </a>
-    <ul class="nav-links" role="list">
-      <li><a href="../products.html" class="active">Products</a></li>
-      <li><a href="../industries.html">Sectors</a></li>
-      <li><a href="../sustainability.html">Sustainability</a></li>
-      <li><a href="../about.html">About</a></li>
-      <li><a href="../compliance.html">Compliance</a></li>
-      <li><a href="../partners.html">Partners</a></li>
-    </ul>
-    <a href="../contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-  </div>
-</nav>
-<div class="nav-mobile" id="nav-mobile">
-  <a href="../products.html">Products</a>
-  <a href="../industries.html">Sectors</a>
-  <a href="../sustainability.html">Sustainability</a>
-  <a href="../about.html">About</a>
-  <a href="../compliance.html">Compliance</a>
-  <a href="../partners.html">Partners</a>
-  <a href="../contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="../js/nav.js"></script>
 
 <!-- ═══ PAGE HERO ═════════════════════════════════════════════ -->
 <section class="page-hero bg-dark">
@@ -54,7 +27,7 @@
     <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4)">
       <span class="badge badge-neutral">On Enquiry</span>
     </div>
-    <p style="max-width:640px;color:rgba(255,255,255,0.55);font-size:var(--text-lg)">Brass, bronze, tool steel, Inconel, and titanium sourced from our global qualified supplier network against your specific requirements — with full AML/KYC and documentation standards applied to every transaction.</p>
+    <p style="max-width:640px;color:rgba(255,255,255,0.55);font-size:var(--text-lg)">Antimony (metallic and concentrate), brass, bronze, tool steel, Inconel, and titanium sourced from our global qualified supplier network against your specific requirements — with full AML/KYC and documentation standards applied to every transaction.</p>
   </div>
 </section>
 
@@ -70,7 +43,7 @@
         <div style="margin-bottom:var(--space-12)">
           <h2 style="margin-bottom:var(--space-3)">Overview</h2>
           <div class="divider-steel"></div>
-          <p style="margin-bottom:var(--space-4)">Vertex Metals' global sourcing capability extends beyond our core metal families to a range of specialist metals and alloys. Whether you require brass for electrical connectors, bronze for marine bearings, tool steel for die manufacturing, or Inconel for high-temperature applications, we source against your specification from our qualified global supplier network.</p>
+          <p style="margin-bottom:var(--space-4)">Vertex Metals' global sourcing capability extends beyond our core metal families to a range of specialist metals and alloys. This includes antimony, sourced as both metallic ingot and concentrate across a range of specifications, alongside brass for electrical connectors, bronze for marine bearings, tool steel for die manufacturing, and Inconel for high-temperature applications — all sourced against your specification from our qualified global supplier network.</p>
           <p style="margin-bottom:var(--space-4)">Every enquiry is assessed against our full AML/KYC framework prior to commitment. We do not source from unqualified or unscreened suppliers, regardless of material category.</p>
           <p>Titanium is sourced exclusively from non-India origins, with full origin verification documentation provided.</p>
         </div>
@@ -86,6 +59,10 @@
           <h2 style="margin-bottom:var(--space-3)">Typical Applications</h2>
           <div class="divider-steel"></div>
           <div class="grid-2" style="gap:var(--space-3)">
+            <div style="display:flex;align-items:flex-start;gap:var(--space-3)">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-top:3px;flex-shrink:0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+              <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Antimony — flame retardants, batteries, semiconductors</span>
+            </div>
             <div style="display:flex;align-items:flex-start;gap:var(--space-3)">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-top:3px;flex-shrink:0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
               <span style="font-size:var(--text-sm);color:var(--color-text-secondary)">Brass — electrical connectors, valves, fittings</span>
@@ -129,6 +106,7 @@
           <h3 style="font-size:var(--text-lg);margin-bottom:var(--space-4)">Materials Available</h3>
           <div class="divider-steel"></div>
           <ul style="list-style:none;display:flex;flex-direction:column;gap:var(--space-3);margin-top:var(--space-4)">
+            <li style="display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);color:var(--color-text-secondary)"><span style="width:6px;height:6px;border-radius:50%;background:var(--color-accent);flex-shrink:0"></span>Antimony (metallic &amp; concentrate) — <a href="antimony.html" style="color:var(--color-accent)">full details →</a></li>
             <li style="display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);color:var(--color-text-secondary)"><span style="width:6px;height:6px;border-radius:50%;background:var(--color-accent);flex-shrink:0"></span>Brass (various grades)</li>
             <li style="display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);color:var(--color-text-secondary)"><span style="width:6px;height:6px;border-radius:50%;background:var(--color-accent);flex-shrink:0"></span>Bronze (various grades)</li>
             <li style="display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);color:var(--color-text-secondary)"><span style="width:6px;height:6px;border-radius:50%;background:var(--color-accent);flex-shrink:0"></span>Tool steel</li>
@@ -157,41 +135,7 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="../index.html" class="nav-logo">
-          <img src="../assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-          <span class="nav-logo-text">Vertex Metals</span>
-        </a>
-        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">No 3 Falcon Cliff<br>9–10 Palace Road, Douglas<br>Isle of Man, IM2 4LD</address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4)">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col"><h4>Products</h4><a href="../products.html">All Products</a><a href="aluminium-alloy-core-wire.html">Aluminium Core Wire</a><a href="copper-products.html">Copper Products</a><a href="stainless-steel.html">Stainless Steel</a><a href="mild-steel.html">Mild Steel</a></div>
-      <div class="footer-col"><h4>Company</h4><a href="../about.html">About Us</a><a href="../sustainability.html">Sustainability</a><a href="../compliance.html">Compliance</a><a href="../partners.html">Partners</a></div>
-      <div class="footer-col"><h4>Legal</h4><a href="../compliance.html">AML/KYC Policy</a><a href="../compliance.html#sanctions">Sanctions Policy</a><a href="../compliance.html#cbam">CBAM Readiness</a></div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated in the Isle of Man under the Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-</script>
+<div id="site-footer"></div>
+<script src="../js/footer.js"></script>
 </body>
 </html>

--- a/products/stainless-steel.html
+++ b/products/stainless-steel.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -14,35 +14,8 @@
 <body>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav scrolled" id="nav">
-  <div class="nav-inner">
-    <a href="../index.html" class="nav-logo" aria-label="Vertex Metals home">
-      <img src="../assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-      <span class="nav-logo-text">Vertex Metals</span>
-    </a>
-    <ul class="nav-links" role="list">
-      <li><a href="../products.html" class="active">Products</a></li>
-      <li><a href="../industries.html">Sectors</a></li>
-      <li><a href="../sustainability.html">Sustainability</a></li>
-      <li><a href="../about.html">About</a></li>
-      <li><a href="../compliance.html">Compliance</a></li>
-      <li><a href="../partners.html">Partners</a></li>
-    </ul>
-    <a href="../contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-  </div>
-</nav>
-<div class="nav-mobile" id="nav-mobile">
-  <a href="../products.html">Products</a>
-  <a href="../industries.html">Sectors</a>
-  <a href="../sustainability.html">Sustainability</a>
-  <a href="../about.html">About</a>
-  <a href="../compliance.html">Compliance</a>
-  <a href="../partners.html">Partners</a>
-  <a href="../contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="../js/nav.js"></script>
 
 <!-- ═══ PAGE HERO ═════════════════════════════════════════════ -->
 <section class="page-hero bg-dark">
@@ -170,41 +143,7 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="../index.html" class="nav-logo">
-          <img src="../assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-          <span class="nav-logo-text">Vertex Metals</span>
-        </a>
-        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">No 3 Falcon Cliff<br>9–10 Palace Road, Douglas<br>Isle of Man, IM2 4LD</address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4)">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col"><h4>Products</h4><a href="../products.html">All Products</a><a href="aluminium-alloy-core-wire.html">Aluminium Core Wire</a><a href="copper-products.html">Copper Products</a><a href="stainless-steel.html">Stainless Steel</a><a href="mild-steel.html">Mild Steel</a></div>
-      <div class="footer-col"><h4>Company</h4><a href="../about.html">About Us</a><a href="../sustainability.html">Sustainability</a><a href="../compliance.html">Compliance</a><a href="../partners.html">Partners</a></div>
-      <div class="footer-col"><h4>Legal</h4><a href="../compliance.html">AML/KYC Policy</a><a href="../compliance.html#sanctions">Sanctions Policy</a><a href="../compliance.html#cbam">CBAM Readiness</a></div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated in the Isle of Man under the Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-</script>
+<div id="site-footer"></div>
+<script src="../js/footer.js"></script>
 </body>
 </html>

--- a/sustainability.html
+++ b/sustainability.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SHARED: update nav and footer in all public pages if changed -->
+<!-- Nav and footer are shared components injected by js/nav.js and js/footer.js — edit those files only -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -73,35 +73,8 @@
 </div>
 
 <!-- ═══ NAVIGATION ═══════════════════════════════════════════ -->
-<nav class="nav scrolled" id="nav">
-  <div class="nav-inner">
-    <a href="index.html" class="nav-logo" aria-label="Vertex Metals home">
-      <img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-      <span class="nav-logo-text">Vertex Metals</span>
-    </a>
-    <ul class="nav-links" role="list">
-      <li><a href="products.html">Products</a></li>
-      <li><a href="industries.html">Sectors</a></li>
-      <li><a href="sustainability.html" class="active">Sustainability</a></li>
-      <li><a href="about.html">About</a></li>
-      <li><a href="compliance.html">Compliance</a></li>
-      <li><a href="partners.html">Partners</a></li>
-    </ul>
-    <a href="contact.html" class="btn btn-primary nav-cta btn-sm">Submit Enquiry</a>
-    <button class="nav-hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-  </div>
-</nav>
-<div class="nav-mobile" id="nav-mobile">
-  <a href="products.html">Products</a>
-  <a href="industries.html">Sectors</a>
-  <a href="sustainability.html" class="active">Sustainability</a>
-  <a href="about.html">About</a>
-  <a href="compliance.html">Compliance</a>
-  <a href="partners.html">Partners</a>
-  <a href="contact.html" class="btn btn-primary">Submit Enquiry</a>
-</div>
+<div id="site-nav"></div>
+<script src="js/nav.js"></script>
 
 <!-- ═══ PAGE HERO ═════════════════════════════════════════════ -->
 <section class="page-hero bg-dark">
@@ -277,61 +250,7 @@
 </section>
 
 <!-- ═══ FOOTER ════════════════════════════════════════════════ -->
-<footer class="footer">
-  <div class="container">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="index.html" class="nav-logo">
-          <img src="assets/images/logo/Vertex%20logo%20emblem.png" alt="Vertex Metals" />
-          <span class="nav-logo-text">Vertex Metals</span>
-        </a>
-        <p>A global sourcer of critical metals and minerals to the UK. Utilising responsible and vetted mills around the world, trust us to keep your supply chain moving efficiently.</p>
-        <div style="margin-top:var(--space-6)">
-          <address style="font-style:normal;font-size:var(--text-sm);color:rgba(255,255,255,0.4);line-height:1.8">No 3 Falcon Cliff<br>9–10 Palace Road, Douglas<br>Isle of Man, IM2 4LD</address>
-          <a href="mailto:sales@vertexmetalsltd.com" style="display:block;margin-top:var(--space-3);font-size:var(--text-sm);color:rgba(255,255,255,0.4)">sales@vertexmetalsltd.com</a>
-        </div>
-      </div>
-      <div class="footer-col">
-        <h4>Products &amp; Sectors</h4>
-        <a href="products.html">All Products</a>
-        <a href="products.html#aluminium">Aluminium Alloys</a>
-        <a href="products.html#copper">Copper &amp; Products</a>
-        <a href="products.html#stainless">Stainless Steel</a>
-        <a href="industries.html">Industries We Serve</a>
-      </div>
-      <div class="footer-col">
-        <h4>Company</h4>
-        <a href="about.html">About Us</a>
-        <a href="sustainability.html">Sustainability</a>
-        <a href="compliance.html">Compliance</a>
-        <a href="partners.html">Become a Partner</a>
-        <a href="contact.html">Contact</a>
-      </div>
-      <div class="footer-col">
-        <h4>Legal &amp; Compliance</h4>
-        <a href="compliance.html">AML/KYC Policy</a>
-        <a href="compliance.html#sanctions">Sanctions Policy</a>
-        <a href="compliance.html#cbam">CBAM Readiness</a>
-        <a href="compliance.html#iso">Quality Standards</a>
-      </div>
-    </div>
-    <div class="footer-bottom">
-      <p>© <span id="year"></span> Vertex Metals Ltd. All rights reserved. Incorporated in the Isle of Man.</p>
-      <p>Incorporated under the Isle of Man Companies Act 1931</p>
-      <p style="margin-top:var(--space-2);opacity:.5">Built by <a href="#" style="color:inherit;text-decoration:none">Vector Business Solutions</a></p>
-    </div>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-  const hamburger = document.getElementById('hamburger');
-  const navMobile = document.getElementById('nav-mobile');
-  hamburger.addEventListener('click', () => {
-    const open = navMobile.classList.toggle('open');
-    hamburger.classList.toggle('open', open);
-    hamburger.setAttribute('aria-expanded', String(open));
-  });
-</script>
+<div id="site-footer"></div>
+<script src="js/footer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Extracted the top nav and footer (previously duplicated across all 13 public pages) into shared components (js/nav.js, js/footer.js), injected via a placeholder div per page — mirrors the pattern already used for the portal sidebar. Fixes a logo inconsistency (two different logo files were in use) and a pre-existing layout bug on products.html where the video banner's margin-top left a gap for the transparent nav to show through. The transparent-over-hero nav effect on scroll is now applied consistently to every page instead of only the homepage.

Compliance page gains UK REACH and Ethics & Modern Slavery sections.

Adds a new Antimony product page (new South American supply, metallic Grade II/B, 12+ MT/month) with a homepage callout linking to it. Supplier identity is kept confidential throughout, per house style.