### PR TITLE
Develop V.0.7.1

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,8 +1,8 @@
 # Vertex Metals — Development Log
 
-**Current Version:** v0.7.0  
+**Current Version:** v0.7.1  
 **Branch:** develop  
-**Last updated:** 11 July 2026  
+**Last updated:** 21 July 2026  
 **Built by:** Vector Business Solutions
 
 The portal displays its current version number at the bottom of the sidebar (`js/portal/sidebar.js`, `PORTAL_VERSION`). Keep that constant in sync with "Current Version" above whenever this log is updated.
@@ -13,6 +13,7 @@ The portal displays its current version number at the bottom of the sidebar (`js
 
 | Version | Branch / PR | Summary |
 |---------|-------------|---------|
+| v0.7.1 | develop | Per-RFQ VAT-exempt toggle (VM is not yet VAT registered, and some trades are 'string' chain trades that never touch the UK) — when off, the VAT column/rate, VAT summary, and VAT total row are omitted entirely from the generated customer quote rather than showing 0%. Sequential quote numbering (`VM-Q-{year}-{4-digit}`, starting at 0050) replacing random reference generation. Fixed a currency-mislabelling bug where a USD-quoted RFQ displayed `£` throughout the Build Quote tab and the customer-facing document despite storing correct USD figures, including the Convert-to-Order flow (USD totals are now converted back to GBP before pre-filling the trade's sell price). Generated quote PDF: clean page-break behaviour (`break-inside:avoid` extended to the Terms and footer blocks, so they move as whole units instead of splitting mid-paragraph across a page boundary), fixed the line-item table overflowing/clipping off the right edge of the page (the on-screen template is wider than an A4 page's printable area — capture width is now constrained to fit), and real "Page X of Y" numbers stamped onto the output PDF (replacing a hardcoded, always-wrong "Page 1 of 1"). Quote document layout compressed to help short quotes fit on a single page — removed a redundant "Estimate" heading that duplicated the header's own label, removed the self-evident "ADDRESS" label, and tightened header/meta/notes/totals/acceptance/terms/footer spacing throughout. Quantity display fix: whole-number MT quantities no longer render with misleading trailing zeros (e.g. "12.000") — new `fmtQty()` helper trims trailing zeros while still allowing up to 3dp for genuine fractional tonnages, applied to both the customer quote and the internal RFQ Lines tab. "Link Supplier Quote" on the Cost Inputs tab now requires selecting which RFQ line the quote applies to (`rfq_line_id`), matching the "Add Supplier Quote" form — previously a linked (as opposed to manually added) supplier quote was left unallocated to any line. |
 | v0.1.0 | Initial commits | Public website (8 pages), Supabase client, basic contact form |
 | v0.2.0 | portal-update-0105 (#15) | Full portal build — order lifecycle management, supplier PO, documents, shipment tracking, invoicing, state machine |
 | v0.3.0 | dev-work-0205 (#25) | Verification queue, KYC/compliance screens, product lines & families, contacts CRM |
@@ -171,6 +172,8 @@ Pending migration — **run this now** (`20260712b_product_lines_compliance_pric
 
 Pending migration — **run this now** (`20260712c_product_line_grades.sql`): new `product_line_grades` table (`product_line_id`, `grade`, `notes`) — a simple add/remove list of grades per product, for products where grade is purely a spec-level detail with no CN code/pricing implications of its own (e.g. Antimony purity grades), as distinct from grades that warrant their own `product_lines` row (e.g. Stainless Steel 304 vs 316 — different CN codes). Managed from a new "Grades" tab on the Product Line detail page.
 
+Pending migration — **run this now** (`20260713_customer_quotes_vat_applicable.sql`): adds `vat_applicable` (boolean, default `true`) to `customer_quotes`. A new "Apply VAT to this quote" toggle on the Build Quote tab lets an operator mark a specific RFQ as VAT-exempt (VM is not yet VAT registered, and some trades are 'string' chain trades that never touch the UK) — when off, the VAT column, VAT rate, VAT summary table, and VAT total row are omitted entirely from the generated customer-facing quote, rather than showing 0%.
+
 Additional one-off SQL applied directly (not in migration files):
 ```sql
 ALTER TABLE supplier_quotes ALTER COLUMN fob_price_usd DROP NOT NULL;
@@ -208,7 +211,6 @@ ALTER TABLE customer_quotes ADD CONSTRAINT customer_quotes_status_check
 - **Director bios on About Us** — hidden for privacy reasons. The section is commented out in `about.html` with a clear note to reinstate. Re-enable when directors are comfortable with public disclosure.
 - **Product pages still reference aluminium wire as the launch product** — the products/aluminium-alloy-core-wire.html page still has India-specific supplier references. Now that the business has pivoted to a broader multi-product model, these pages may need a copy review.
 - **Verification queue RLS** — the verification queue currently allows any authenticated user to see and act on all queue items regardless of role. Four-eyes constraints are enforced (drafter cannot approve their own items) but finer-grained role-based access control (e.g. only Finance role sees invoice review items) has not been applied.
-- **PDF output quality** — the customer-facing quote PDF (html2pdf.js) renders well for simple quotes but may paginate awkwardly for quotes with many line items. Long quotes with 6+ lines may need a CSS page-break rule.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -172,7 +172,7 @@ Pending migration — **run this now** (`20260712b_product_lines_compliance_pric
 
 Pending migration — **run this now** (`20260712c_product_line_grades.sql`): new `product_line_grades` table (`product_line_id`, `grade`, `notes`) — a simple add/remove list of grades per product, for products where grade is purely a spec-level detail with no CN code/pricing implications of its own (e.g. Antimony purity grades), as distinct from grades that warrant their own `product_lines` row (e.g. Stainless Steel 304 vs 316 — different CN codes). Managed from a new "Grades" tab on the Product Line detail page.
 
-Pending migration — **run this now** (`20260713_customer_quotes_vat_applicable.sql`): adds `vat_applicable` (boolean, default `true`) to `customer_quotes`. A new "Apply VAT to this quote" toggle on the Build Quote tab lets an operator mark a specific RFQ as VAT-exempt (VM is not yet VAT registered, and some trades are 'string' chain trades that never touch the UK) — when off, the VAT column, VAT rate, VAT summary table, and VAT total row are omitted entirely from the generated customer-facing quote, rather than showing 0%.
+Applied (2026-07-13): `20260713_customer_quotes_vat_applicable.sql` — adds `vat_applicable` (boolean, default `true`) to `customer_quotes`. A new "Apply VAT to this quote" toggle on the Build Quote tab lets an operator mark a specific RFQ as VAT-exempt (VM is not yet VAT registered, and some trades are 'string' chain trades that never touch the UK) — when off, the VAT column, VAT rate, VAT summary table, and VAT total row are omitted entirely from the generated customer-facing quote, rather than showing 0%.
 
 Additional one-off SQL applied directly (not in migration files):
 ```sql

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -152,11 +152,7 @@ Additional one-off SQL applied directly (v0.6.1):
 ALTER TABLE contacts ADD COLUMN IF NOT EXISTS year_established integer;
 ```
 
-Pending migrations (apply before v0.6.0 goes live in production):
-```sql
-ALTER TABLE rfq_submissions ADD COLUMN IF NOT EXISTS contact_id uuid REFERENCES contacts(id);
-ALTER TABLE logistics_quotes  ADD COLUMN IF NOT EXISTS price_flat_usd numeric(12,2);
-```
+Applied: `rfq_submissions.contact_id` (uuid, references `contacts(id)`) and `logistics_quotes.price_flat_usd` (numeric(12,2)) — added for v0.6.0.
 
 Applied (2026-07-10): `20260710_rfq_pricing_settings.sql` — adds `pricing_scenario_supplier_id`, `pricing_logistics_quote_id`, `pricing_fx_rate`, `pricing_insurance_pct`, `pricing_model`, `pricing_markup_pct` (renamed back to `pricing_margin_pct` on 2026-07-11 — see below) to `rfq_submissions` so the calculator's FX rate/insurance/model/margin selections persist per RFQ instead of resetting to hardcoded defaults every time the operator navigates away and back.
 
@@ -168,9 +164,9 @@ Applied (2026-07-11): `20260711_rfq_pricing_margin_rename.sql` — renames `rfq_
 
 Applied (2026-07-11): `20260712_rfq_lines_product_type.sql` — adds `product_type` to `rfq_lines` so "Type" (bar, rod, ingot, powder, etc.) can be captured per line at the Enquiry stage (Quote Lines table + Add/Edit Line modal), not just later in the Build Quote tab. Falls back to the linked product line's catalogue default when left blank; the Quote Lines table now shows Product/Type/Specification columns matching the final customer quote, so gaps are visible before the quote is generated.
 
-Pending migration — **run this now** (`20260712b_product_lines_compliance_pricing.sql`): adds `reach_uk_regulated`/`reach_uk_notes`, `reach_eu_regulated`/`reach_eu_notes`, `import_restrictions_notes`, and `price_reference_source`/`price_reference_code`/`price_reference_updated_at` to `product_lines`. Powers the new Product Line detail page (`product-lines/detail.html`) — a standalone page per product (like the supplier detail page), reached by clicking a product in the Product Lines list. Has Overview / Compliance / Usage tabs, Edit and Delete actions (delete requires typing the product name to confirm, and is blocked if the product line is referenced by any RFQ, RFQ line, supplier quote, or customer quote line).
+Applied: `20260712b_product_lines_compliance_pricing.sql` — adds `reach_uk_regulated`/`reach_uk_notes`, `reach_eu_regulated`/`reach_eu_notes`, `import_restrictions_notes`, and `price_reference_source`/`price_reference_code`/`price_reference_updated_at` to `product_lines`. Powers the new Product Line detail page (`product-lines/detail.html`) — a standalone page per product (like the supplier detail page), reached by clicking a product in the Product Lines list. Has Overview / Compliance / Usage tabs, Edit and Delete actions (delete requires typing the product name to confirm, and is blocked if the product line is referenced by any RFQ, RFQ line, supplier quote, or customer quote line).
 
-Pending migration — **run this now** (`20260712c_product_line_grades.sql`): new `product_line_grades` table (`product_line_id`, `grade`, `notes`) — a simple add/remove list of grades per product, for products where grade is purely a spec-level detail with no CN code/pricing implications of its own (e.g. Antimony purity grades), as distinct from grades that warrant their own `product_lines` row (e.g. Stainless Steel 304 vs 316 — different CN codes). Managed from a new "Grades" tab on the Product Line detail page.
+Applied: `20260712c_product_line_grades.sql` — new `product_line_grades` table (`product_line_id`, `grade`, `notes`) — a simple add/remove list of grades per product, for products where grade is purely a spec-level detail with no CN code/pricing implications of its own (e.g. Antimony purity grades), as distinct from grades that warrant their own `product_lines` row (e.g. Stainless Steel 304 vs 316 — different CN codes). Managed from a new "Grades" tab on the Product Line detail page.
 
 Applied (2026-07-13): `20260713_customer_quotes_vat_applicable.sql` — adds `vat_applicable` (boolean, default `true`) to `customer_quotes`. A new "Apply VAT to this quote" toggle on the Build Quote tab lets an operator mark a specific RFQ as VAT-exempt (VM is not yet VAT registered, and some trades are 'string' chain trades that never touch the UK) — when off, the VAT column, VAT rate, VAT summary table, and VAT total row are omitted entirely from the generated customer-facing quote, rather than showing 0%.
 

--- a/customer-quote/index.html
+++ b/customer-quote/index.html
@@ -31,19 +31,16 @@
     .cq-accepted-banner { background:#d1fae5; border:1px solid #6ee7b7; border-radius:var(--radius); padding:var(--space-4) var(--space-6); margin-bottom:var(--space-6); color:#065f46; font-weight:600; }
 
     /* Quote document */
-    #quote-print-template { background:#fff; border-radius:var(--radius); box-shadow:0 1px 4px rgba(0,0,0,.08); padding:40px 48px; font-family:'DM Sans',sans-serif; font-size:13px; color:#0a1728; line-height:1.5; }
+    #quote-print-template { background:#fff; border-radius:var(--radius); box-shadow:0 1px 4px rgba(0,0,0,.08); padding:28px 40px; font-family:'DM Sans',sans-serif; font-size:13px; color:#0a1728; line-height:1.5; }
 
-    .qdoc-header { display:flex; justify-content:space-between; align-items:flex-start; margin-bottom:32px; padding-bottom:24px; border-bottom:2px solid #0a1728; }
-    .qdoc-logo { font-family:'Syne',sans-serif; font-size:24px; font-weight:700; color:#0a1728; letter-spacing:-.02em; }
+    .qdoc-header { display:flex; justify-content:space-between; align-items:flex-start; margin-bottom:18px; padding-bottom:14px; border-bottom:2px solid #0a1728; }
+    .qdoc-logo { font-family:'Syne',sans-serif; font-size:22px; font-weight:700; color:#0a1728; letter-spacing:-.02em; }
     .qdoc-logo span { color:#7ab8d4; }
-    .qdoc-header-contact { font-size:11px; color:#666; line-height:1.7; text-align:right; }
+    .qdoc-header-contact { font-size:11px; color:#666; line-height:1.6; text-align:right; }
     .qdoc-header-contact a { color:#7ab8d4; text-decoration:none; }
 
-    .qdoc-heading { font-family:'Syne',sans-serif; font-size:28px; font-weight:700; color:#7ab8d4; margin-bottom:28px; letter-spacing:-.01em; }
-
-    .qdoc-meta { display:grid; grid-template-columns:1fr 1fr; gap:24px; margin-bottom:32px; }
-    .qdoc-address { font-size:13px; line-height:1.8; }
-    .qdoc-address .label { font-size:10px; text-transform:uppercase; letter-spacing:.08em; color:#999; margin-bottom:6px; display:block; }
+    .qdoc-meta { display:grid; grid-template-columns:1fr 1fr; gap:24px; margin-bottom:16px; }
+    .qdoc-address { font-size:13px; line-height:1.45; }
     .qdoc-ref-block { text-align:right; }
     .qdoc-ref-row { display:flex; justify-content:flex-end; gap:24px; align-items:baseline; margin-bottom:4px; }
     .qdoc-ref-row .key { font-size:10px; text-transform:uppercase; letter-spacing:.08em; color:#999; }
@@ -59,26 +56,40 @@
     .qdoc-table tbody td.amount { text-align:right; font-weight:600; font-variant-numeric:tabular-nums; }
     .alt-tag { display:inline-block; font-size:9px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; background:#7ab8d4; color:#fff; border-radius:2px; padding:1px 5px; margin-left:4px; vertical-align:middle; }
 
-    .qdoc-notes { background:#f4f5f7; border-radius:4px; padding:14px 18px; margin:20px 0; font-size:12px; color:#555; white-space:pre-wrap; }
+    .qdoc-notes { background:#f4f5f7; border-radius:4px; padding:10px 14px; margin:14px 0; font-size:12px; color:#555; white-space:pre-wrap; }
 
-    .qdoc-totals { margin-top:16px; }
-    .qdoc-totals-row { display:flex; justify-content:flex-end; gap:24px; padding:5px 12px; font-size:13px; }
+    .qdoc-totals { margin-top:10px; }
+    .qdoc-totals-row { display:flex; justify-content:flex-end; gap:24px; padding:4px 12px; font-size:13px; }
     .qdoc-totals-row .label { color:#666; min-width:120px; text-align:right; }
     .qdoc-totals-row .amount { min-width:90px; text-align:right; font-variant-numeric:tabular-nums; }
-    .qdoc-totals-row.total { border-top:2px solid #0a1728; margin-top:6px; padding-top:10px; font-weight:700; font-size:16px; font-family:'Syne',sans-serif; }
+    .qdoc-totals-row.total { border-top:2px solid #0a1728; margin-top:4px; padding-top:8px; font-weight:700; font-size:16px; font-family:'Syne',sans-serif; }
 
-    .qdoc-vat-summary { margin-top:20px; font-size:11px; }
+    .qdoc-vat-summary { margin-top:14px; font-size:11px; }
     .qdoc-vat-summary table { border-collapse:collapse; }
     .qdoc-vat-summary th { font-size:10px; text-transform:uppercase; letter-spacing:.06em; color:#999; padding:4px 16px 4px 0; border-bottom:1px solid #e5e7eb; }
     .qdoc-vat-summary td { padding:4px 16px 4px 0; border-bottom:1px solid #f3f4f6; }
 
-    .qdoc-acceptance { margin-top:32px; padding-top:20px; border-top:1px solid #e5e7eb; display:grid; grid-template-columns:1fr 1fr; gap:32px; }
-    .qdoc-acceptance-field { border-bottom:1px solid #ccc; padding-bottom:4px; margin-top:24px; min-height:28px; }
+    .qdoc-acceptance { margin-top:20px; padding-top:14px; border-top:1px solid #e5e7eb; display:grid; grid-template-columns:1fr 1fr; gap:32px; }
+    .qdoc-acceptance-field { border-bottom:1px solid #ccc; padding-bottom:4px; margin-top:16px; min-height:24px; }
     .qdoc-acceptance-label { font-size:10px; text-transform:uppercase; letter-spacing:.08em; color:#999; margin-top:6px; }
 
-    .qdoc-terms { margin-top:24px; padding-top:16px; border-top:1px solid #e5e7eb; font-size:11px; color:#888; white-space:pre-wrap; }
+    .qdoc-terms { margin-top:16px; padding-top:10px; border-top:1px solid #e5e7eb; font-size:11px; color:#888; white-space:pre-wrap; }
 
-    .qdoc-footer { margin-top:32px; padding-top:12px; border-top:1px solid #e5e7eb; display:flex; justify-content:space-between; font-size:10px; color:#bbb; }
+    .qdoc-footer { margin-top:16px; padding-top:8px; border-top:1px solid #e5e7eb; display:flex; justify-content:space-between; font-size:10px; color:#bbb; }
+
+    /* Clean PDF/print pagination — don't split a table row or a whole block
+       across a page boundary; break before a block instead if it doesn't fit. */
+    .qdoc-table tr,
+    .qdoc-header,
+    .qdoc-meta,
+    .qdoc-totals,
+    .qdoc-vat-summary,
+    .qdoc-acceptance,
+    .qdoc-terms,
+    .qdoc-footer {
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }
 
     /* Loading / error states */
     #cq-loading { padding:var(--space-16); text-align:center; color:var(--color-text-muted); }

--- a/docs/migrations/20260713_customer_quotes_vat_applicable.sql
+++ b/docs/migrations/20260713_customer_quotes_vat_applicable.sql
@@ -1,0 +1,6 @@
+-- Lets a specific RFQ/quote be marked VAT-exempt (VM is not yet VAT
+-- registered, and some trades are 'string' chain trades that never touch
+-- the UK). When false, the customer-facing quote omits the VAT column,
+-- VAT summary, and VAT total row entirely rather than showing 0%.
+ALTER TABLE customer_quotes
+  ADD COLUMN IF NOT EXISTS vat_applicable boolean NOT NULL DEFAULT true;

--- a/js/customer-quote.js
+++ b/js/customer-quote.js
@@ -12,6 +12,13 @@ function fmt(n, dp = 2) {
   if (n == null || isNaN(n)) return '—';
   return Number(n).toLocaleString('en-GB', { minimumFractionDigits: dp, maximumFractionDigits: dp });
 }
+// Quantities: show up to 3dp for MT (fractional tonnages happen) or 2dp otherwise,
+// but drop trailing zeros so a whole number like 12 reads as "12", not "12.000".
+function fmtQty(n, unit) {
+  if (n == null || isNaN(n)) return '—';
+  const dp = unit === 'MT' ? 3 : 2;
+  return Number(n).toLocaleString('en-GB', { minimumFractionDigits: 0, maximumFractionDigits: dp });
+}
 function fmtDate(d) { return d ? new Date(d).toLocaleDateString('en-GB') : '—'; }
 
 const VERTEX = {
@@ -81,7 +88,8 @@ function showError() {
 
 function renderQuote(cq, lines) {
   const today = fmtDate(new Date());
-  const sym = cq.currency === 'USD' ? '$' : '£';
+  const sym   = cq.currency === 'USD' ? '$' : '£';
+  const vatOn = cq.vat_applicable !== false;
 
   // Build customer address
   const addrLines = [
@@ -103,27 +111,30 @@ function renderQuote(cq, lines) {
       <td>${esc(l.product_type || '—')}</td>
       <td>${esc(l.grade_specification || '—')}</td>
       <td>${esc(l.description)}</td>
-      <td>${l.vat_rate != null ? `${fmt(l.vat_rate, 0)}%` : '—'}</td>
-      <td style="text-align:right">${l.quantity != null ? fmt(l.quantity, l.unit === 'MT' ? 3 : 2) : '—'}</td>
+      ${vatOn ? `<td>${l.vat_rate != null ? `${fmt(l.vat_rate, 0)}%` : '—'}</td>` : ''}
+      <td style="text-align:right">${l.quantity != null ? fmtQty(l.quantity, l.unit) : '—'}</td>
       <td>${esc(l.unit || 'MT')}</td>
       <td style="text-align:right">${l.unit_price_gbp != null ? `${sym}${fmt(l.unit_price_gbp)}` : '—'}</td>
       <td class="amount">${l.amount_gbp != null ? `${sym}${fmt(l.amount_gbp)}` : '—'}</td>
     </tr>`).join('');
 
-  // VAT summary (group by rate)
-  const vatGroups = {};
-  lines.forEach(l => {
-    const rate = l.vat_rate ?? 20;
-    if (!vatGroups[rate]) vatGroups[rate] = { vat: 0, net: 0 };
-    vatGroups[rate].net += parseFloat(l.amount_gbp || 0);
-    vatGroups[rate].vat += parseFloat(l.vat_amount_gbp || 0);
-  });
-  const vatSummaryRows = Object.entries(vatGroups).map(([rate, g]) => `
-    <tr>
-      <td>VAT @ ${rate}%</td>
-      <td>${sym}${fmt(g.vat)}</td>
-      <td>${sym}${fmt(g.net)}</td>
-    </tr>`).join('');
+  // VAT summary (group by rate) — omitted entirely when VAT is off for this quote
+  let vatSummaryRows = '';
+  if (vatOn) {
+    const vatGroups = {};
+    lines.forEach(l => {
+      const rate = l.vat_rate ?? 20;
+      if (!vatGroups[rate]) vatGroups[rate] = { vat: 0, net: 0 };
+      vatGroups[rate].net += parseFloat(l.amount_gbp || 0);
+      vatGroups[rate].vat += parseFloat(l.vat_amount_gbp || 0);
+    });
+    vatSummaryRows = Object.entries(vatGroups).map(([rate, g]) => `
+      <tr>
+        <td>VAT @ ${rate}%</td>
+        <td>${sym}${fmt(g.vat)}</td>
+        <td>${sym}${fmt(g.net)}</td>
+      </tr>`).join('');
+  }
 
   // Notes block (lead time, payment terms, etc.)
   const noteItems = [
@@ -138,7 +149,7 @@ function renderQuote(cq, lines) {
     <div class="qdoc-header">
       <div>
         <div class="qdoc-logo">VERTEX <span>METALS</span></div>
-        <div style="font-size:11px;color:#666;margin-top:8px;line-height:1.7">
+        <div style="font-size:11px;color:#666;margin-top:6px;line-height:1.5">
           ${esc(VERTEX.addr1)}<br>${esc(VERTEX.addr2)}<br>${esc(VERTEX.addr3)}<br>
           <a href="mailto:${esc(VERTEX.email)}" style="color:#7ab8d4">${esc(VERTEX.email)}</a>
         </div>
@@ -151,13 +162,9 @@ function renderQuote(cq, lines) {
       </div>
     </div>
 
-    <!-- Heading -->
-    <div class="qdoc-heading">Estimate</div>
-
     <!-- Address + ref -->
     <div class="qdoc-meta">
       <div>
-        <span class="qdoc-address label">ADDRESS</span>
         <div class="qdoc-address">
           ${addrLines.map(l => esc(l)).join('<br>')}
           ${vatLine ? `<br><em style="font-size:11px;color:#888">${esc(vatLine)}</em>` : ''}
@@ -174,7 +181,7 @@ function renderQuote(cq, lines) {
           <th>TYPE</th>
           <th>SPECIFICATION</th>
           <th>DESCRIPTION</th>
-          <th>VAT</th>
+          ${vatOn ? '<th>VAT</th>' : ''}
           <th style="text-align:right">QTY</th>
           <th>UNIT</th>
           <th style="text-align:right">PRICE</th>
@@ -182,7 +189,7 @@ function renderQuote(cq, lines) {
         </tr>
       </thead>
       <tbody>
-        ${lineRows || '<tr><td colspan="10" style="text-align:center;color:#999;padding:16px">No line items</td></tr>'}
+        ${lineRows || `<tr><td colspan="${vatOn ? 10 : 9}" style="text-align:center;color:#999;padding:16px">No line items</td></tr>`}
       </tbody>
     </table>
 
@@ -192,7 +199,7 @@ function renderQuote(cq, lines) {
     <!-- Totals -->
     <div class="qdoc-totals">
       <div class="qdoc-totals-row"><span class="label">SUBTOTAL</span><span class="amount">${cq.subtotal_gbp ? `${sym}${fmt(cq.subtotal_gbp)}` : '—'}</span></div>
-      <div class="qdoc-totals-row"><span class="label">VAT TOTAL</span><span class="amount">${cq.vat_total_gbp ? `${sym}${fmt(cq.vat_total_gbp)}` : '—'}</span></div>
+      ${vatOn ? `<div class="qdoc-totals-row"><span class="label">VAT TOTAL</span><span class="amount">${cq.vat_total_gbp ? `${sym}${fmt(cq.vat_total_gbp)}` : '—'}</span></div>` : ''}
       <div class="qdoc-totals-row total"><span class="label">TOTAL</span><span class="amount">${cq.total_gbp ? `${sym}${fmt(cq.total_gbp)}` : '—'}</span></div>
     </div>
 
@@ -224,7 +231,6 @@ function renderQuote(cq, lines) {
     <!-- Footer -->
     <div class="qdoc-footer">
       <span>${esc(VERTEX.name)} — ${esc(VERTEX.reg)}</span>
-      <span>Page 1 of 1</span>
     </div>
   `;
 }
@@ -263,13 +269,43 @@ async function acceptQuote() {
 function downloadPdf() {
   const template = document.getElementById('quote-print-template');
   const ref      = document.title.split('—')[0].trim() || 'VM-Quote';
+
+  // On screen the template can render wider (up to 860px, see .cq-page-wrap)
+  // than an A4 page's printable width (~718px at 190mm usable), which was
+  // causing the right-hand columns to fall outside the page and get cropped.
+  // Force a page-safe width just for the capture, then restore it.
+  const prevWidth    = template.style.width;
+  const prevMaxWidth = template.style.maxWidth;
+  template.style.width    = '700px';
+  template.style.maxWidth = '700px';
+
   html2pdf().set({
     margin:      [10, 10, 10, 10],
     filename:    `${ref}.pdf`,
     image:       { type: 'jpeg', quality: 0.98 },
     html2canvas: { scale: 2, useCORS: true },
     jsPDF:       { unit: 'mm', format: 'a4', orientation: 'portrait' },
-  }).from(template).save();
+    // 'css' honours break-inside/page-break-inside:avoid (table rows, totals,
+    // etc. — see customer-quote/index.html). Deliberately not using 'avoid-all':
+    // its automatic heuristics tend to push whole trailing sections (e.g.
+    // Terms & Conditions) onto a needless extra page even when there's room.
+    pagebreak:   { mode: ['css'] },
+  }).from(template).toPdf().get('pdf').then(pdf => {
+    // Stamp real "Page X of Y" on every page — the document's actual page
+    // count isn't known until the PDF is fully paginated.
+    const pageCount = pdf.internal.getNumberOfPages();
+    const pageW = pdf.internal.pageSize.getWidth();
+    const pageH = pdf.internal.pageSize.getHeight();
+    for (let i = 1; i <= pageCount; i++) {
+      pdf.setPage(i);
+      pdf.setFontSize(8);
+      pdf.setTextColor(160);
+      pdf.text(`Page ${i} of ${pageCount}`, pageW - 10, pageH - 6, { align: 'right' });
+    }
+  }).save().then(() => {
+    template.style.width    = prevWidth;
+    template.style.maxWidth = prevMaxWidth;
+  });
 }
 
 // Init on load

--- a/js/portal/rfq.js
+++ b/js/portal/rfq.js
@@ -10,6 +10,13 @@ function fmt(n, dp = 2) {
   if (n == null || isNaN(n)) return '—';
   return Number(n).toLocaleString('en-GB', { minimumFractionDigits: dp, maximumFractionDigits: dp });
 }
+// Quantities: show up to 3dp for MT (fractional tonnages happen) or 0dp otherwise,
+// but drop trailing zeros so a whole number like 12 reads as "12", not "12.000".
+function fmtQty(n, unit) {
+  if (n == null || isNaN(n)) return '—';
+  const dp = unit === 'MT' ? 3 : 0;
+  return Number(n).toLocaleString('en-GB', { minimumFractionDigits: 0, maximumFractionDigits: dp });
+}
 function fmtDate(d) { return d ? new Date(d).toLocaleDateString('en-GB') : '—'; }
 
 function statusBadge(s) {
@@ -300,6 +307,7 @@ let _pricedLines        = [];    // calculated results per rfq_line
 let _calc = { pl: null, sqData: null, lqData: null, overheadTotal: 0, qty: 0, fx: 1.27, ins: 0.5, minMargin: 5, model: 'standard' };
 let _calcApplied    = null; // pre-fill data passed to renderBuildTab (object OR array)
 let _quoteCurrency  = 'GBP'; // customer-facing quote currency; set on Build Quote tab
+let _quoteVatApplicable = true; // false for VAT-exempt/string-chain trades; set on Build Quote tab
 let _costsLocked    = false; // true once a quote has been issued (quoted/accepted/etc.)
 
 // ── Tab management ────────────────────────────────────────────────────────────
@@ -663,7 +671,7 @@ function renderRfqLinesSection(lines) {
           <td style="font-size:var(--text-sm);color:${l.product_type ? 'var(--color-text-primary)' : 'var(--color-text-muted)'}">${esc(l.product_type || l.product_lines?.physical_form || '—')}${!l.product_type && l.product_lines?.physical_form ? ' <span style="font-size:9px;color:var(--color-text-muted)">(default)</span>' : ''}</td>
           <td style="font-size:var(--text-sm);color:var(--color-text-muted)">${esc(l.grade_specification || '—')}</td>
           <td style="font-weight:500">${esc(l.description)}</td>
-          <td>${l.quantity != null ? fmt(l.quantity, l.quantity_unit === 'MT' ? 3 : 0) : '—'}</td>
+          <td>${l.quantity != null ? fmtQty(l.quantity, l.quantity_unit) : '—'}</td>
           <td>${esc(l.quantity_unit || 'MT')}</td>
           <td style="white-space:nowrap">
             <button onclick="openEditRfqLineModal('${esc(l.id)}')" class="btn btn-ghost btn-sm" style="color:var(--color-text-muted)">Edit</button>
@@ -2035,8 +2043,9 @@ async function renderBuildTab() {
     contactAddr = contacts?.[0] || null;
   }
 
-  // Sync quote currency from saved draft, then fall back to module state
+  // Sync quote currency and VAT applicability from saved draft, then fall back to module state
   if (cq?.currency) _quoteCurrency = cq.currency;
+  if (cq && cq.vat_applicable != null) _quoteVatApplicable = cq.vat_applicable;
 
   // Initialise working line items — prefer fresh calculator output (allows currency change),
   // then existing draft, then blank
@@ -2166,6 +2175,16 @@ async function renderBuildTab() {
               ${_quoteCurrency === 'GBP' && _calc.fx ? `Converted from USD at £1 = $${fmt(_calc.fx, 3)}` : 'No conversion — prices shown as USD'}
             </div>
           </div>
+          <div class="form-group">
+            <label class="form-label">VAT</label>
+            <label style="display:flex;align-items:center;gap:var(--space-2);cursor:pointer;margin-top:var(--space-2)">
+              <input type="checkbox" id="bq-vat-applicable" ${_quoteVatApplicable ? 'checked' : ''} onchange="_quoteVatApplicable=this.checked;renderBuildTab()" />
+              Apply VAT to this quote
+            </label>
+            <div style="font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)">
+              ${_quoteVatApplicable ? 'Standard rate(s) below apply per line.' : 'Off — no VAT column, rate, or total will appear on the generated quote (e.g. pre-registration or a string chain trade outside the UK).'}
+            </div>
+          </div>
           <div class="form-group" style="grid-column:1/-1">
             <label class="form-label">Payment Terms</label>
             <select class="form-select" id="bq-payment-select" onchange="document.getElementById('bq-payment-other').style.display=this.value==='other'?'block':'none'">
@@ -2207,7 +2226,7 @@ async function renderBuildTab() {
           <th style="width:70px">Qty</th>
           <th style="width:70px">Unit</th>
           <th style="width:90px">Unit Price (${_quoteCurrency === 'USD' ? '$' : '£'})</th>
-          <th style="width:70px">VAT %</th>
+          <th style="width:70px">${_quoteVatApplicable ? 'VAT %' : 'VAT (off)'}</th>
           <th style="width:90px">Amount (${_quoteCurrency === 'USD' ? '$' : '£'})</th>
           <th style="width:30px"></th>
         </tr></thead>
@@ -2226,9 +2245,9 @@ async function renderBuildTab() {
         <p style="font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-muted);margin-bottom:var(--space-2)">Additional Costs (from Cost Inputs tab)</p>
         <div id="overhead-totals-summary" style="font-size:var(--text-sm);color:var(--color-text-muted)">${_quoteCurrency === 'USD' ? `$${fmt(overheadTotal * (_calc.fx || 1.27))}` : `£${fmt(overheadTotal)}`} total overheads</div>
       </div>` : ''}
-      <div class="totals-row"><span>Subtotal (ex. VAT)</span><span id="t-subtotal" style="font-family:var(--font-display)">—</span></div>
-      <div class="totals-row"><span>VAT</span><span id="t-vat" style="font-family:var(--font-display)">—</span></div>
-      <div class="totals-row total-final"><span>Total (inc. VAT)</span><span id="t-total">—</span></div>
+      <div class="totals-row"><span>${_quoteVatApplicable ? 'Subtotal (ex. VAT)' : 'Subtotal'}</span><span id="t-subtotal" style="font-family:var(--font-display)">—</span></div>
+      <div class="totals-row" id="t-vat-row" style="${_quoteVatApplicable ? '' : 'display:none'}"><span>VAT</span><span id="t-vat" style="font-family:var(--font-display)">—</span></div>
+      <div class="totals-row total-final"><span>${_quoteVatApplicable ? 'Total (inc. VAT)' : 'Total'}</span><span id="t-total">—</span></div>
     </div>
 
     <!-- Notes & T&Cs -->
@@ -2275,7 +2294,7 @@ function renderLineItemsBody() {
         ${UNITS.map(u => `<option value="${u}"${u===(l.unit||'MT')?' selected':''}>${u}</option>`).join('')}
       </select></td>
       <td><input class="line-input" type="number" value="${l.unit_price_gbp||''}" step="0.01" min="0" oninput="_quoteLines[${i}].unit_price_gbp=parseFloat(this.value)||null;recalcLine(${i})" /></td>
-      <td><input class="line-input" type="number" value="${l.vat_rate??20}" step="0.5" min="0" oninput="_quoteLines[${i}].vat_rate=parseFloat(this.value)||0;recalcLine(${i})" /></td>
+      <td><input class="line-input" type="number" value="${l.vat_rate??20}" step="0.5" min="0" ${_quoteVatApplicable ? '' : 'disabled title="VAT is off for this quote"'} oninput="_quoteLines[${i}].vat_rate=parseFloat(this.value)||0;recalcLine(${i})" /></td>
       <td style="font-family:var(--font-display);font-weight:600;text-align:right" id="line-amount-${i}">${l.amount_gbp ? `${_quoteCurrency === 'USD' ? '$' : '£'}${fmt(l.amount_gbp)}` : '—'}</td>
       <td><button type="button" onclick="removeQuoteLine(${i})" style="background:none;border:none;cursor:pointer;color:var(--color-text-muted);font-size:var(--text-lg);line-height:1;padding:var(--space-1)" title="Remove line">×</button></td>
     </tr>`).join('');
@@ -2298,7 +2317,7 @@ function recalcLine(i) {
   const l = _quoteLines[i];
   const qty   = parseFloat(l.quantity)      || 0;
   const price = parseFloat(l.unit_price_gbp) || 0;
-  const vat   = parseFloat(l.vat_rate)       || 0;
+  const vat   = _quoteVatApplicable ? (parseFloat(l.vat_rate) || 0) : 0;
   l.amount_gbp     = qty * price;
   l.vat_amount_gbp = l.amount_gbp * (vat / 100);
   const sym = _quoteCurrency === 'USD' ? '$' : '£';
@@ -2310,7 +2329,8 @@ function recalcLine(i) {
 function recalcTotals() {
   const sym = _quoteCurrency === 'USD' ? '$' : '£';
   const subtotal  = _quoteLines.reduce((s, l) => s + (parseFloat(l.amount_gbp) || 0), 0);
-  const vatTotal  = _quoteLines.reduce((s, l) => s + (parseFloat(l.vat_amount_gbp) || 0), 0);
+  // Master toggle overrides any stale per-line VAT amounts left over from before it was switched off.
+  const vatTotal  = _quoteVatApplicable ? _quoteLines.reduce((s, l) => s + (parseFloat(l.vat_amount_gbp) || 0), 0) : 0;
   const grandTotal = subtotal + vatTotal;
 
   const tSub  = document.getElementById('t-subtotal');
@@ -2347,8 +2367,9 @@ async function saveQuoteDraft(publish = false) {
     return null;
   }
 
+  const vatApplicable = document.getElementById('bq-vat-applicable')?.checked ?? _quoteVatApplicable;
   const subtotal   = lines.reduce((s,l) => s + (parseFloat(l.amount_gbp)||0), 0);
-  const vatTotal   = lines.reduce((s,l) => s + (parseFloat(l.vat_amount_gbp)||0), 0);
+  const vatTotal   = vatApplicable ? lines.reduce((s,l) => s + (parseFloat(l.vat_amount_gbp)||0), 0) : 0;
   const grandTotal = subtotal + vatTotal;
 
   const qPayload = {
@@ -2374,6 +2395,7 @@ async function saveQuoteDraft(publish = false) {
     subtotal_gbp:             subtotal   || null,
     vat_total_gbp:            vatTotal   || null,
     total_gbp:                grandTotal || null,
+    vat_applicable:           vatApplicable,
     status:                   publish ? 'issued' : 'draft',
   };
 
@@ -2408,8 +2430,8 @@ async function saveQuoteDraft(publish = false) {
     unit:              l.unit || 'MT',
     unit_price_gbp:    parseFloat(l.unit_price_gbp) || null,
     amount_gbp:        parseFloat(l.amount_gbp) || null,
-    vat_rate:          parseFloat(l.vat_rate) ?? 20,
-    vat_amount_gbp:    parseFloat(l.vat_amount_gbp) || null,
+    vat_rate:          vatApplicable ? (parseFloat(l.vat_rate) ?? 20) : 0,
+    vat_amount_gbp:    vatApplicable ? (parseFloat(l.vat_amount_gbp) || null) : 0,
     is_alternative:    !!l.is_alternative,
   }));
   const { error: lineErr } = await supabaseClient.from('customer_quote_lines').insert(lineRows);
@@ -2511,9 +2533,15 @@ async function openLinkSupplierQuoteModal() {
   const opts = (quotes || []).map(q =>
     `<option value="${esc(q.id)}">${esc(q.contacts?.company_name || '?')} — ${esc(q.product)} — $${fmt(q.fob_price_usd)}/MT</option>`
   ).join('');
+  const lineOpts = _rfqLines.map(l =>
+    `<option value="${esc(l.id)}">Line ${l.line_number}${l.is_alternative ? ' (alt)' : ''} — ${esc(l.description)}</option>`
+  ).join('');
   showLinkModal('Link Supplier Quote', `
     <div class="form-group"><label class="form-label">Select Supplier Quote</label>
       <select class="form-select" id="link-sq-select"><option value="">— Select —</option>${opts}</select>
+    </div>
+    <div class="form-group"><label class="form-label">Quote Line <span style="color:var(--color-danger)">*</span></label>
+      <select class="form-select" id="link-sq-line"><option value="">— Which line is this quote for? —</option>${lineOpts}</select>
     </div>
     <div id="link-sq-alert" class="alert" style="display:none;margin-top:var(--space-3)"></div>
     <div style="display:flex;gap:var(--space-3);margin-top:var(--space-4)">
@@ -2525,10 +2553,12 @@ async function openLinkSupplierQuoteModal() {
 }
 
 async function submitLinkSupplierQuote() {
-  const id = document.getElementById('link-sq-select').value;
-  const al = document.getElementById('link-sq-alert');
-  if (!id) { al.style.display='block'; al.className='alert alert-error'; al.textContent='Select a quote.'; return; }
-  const { error } = await supabaseClient.from('supplier_quotes').update({ rfq_id: _rfqId }).eq('id', id);
+  const id     = document.getElementById('link-sq-select').value;
+  const lineId = document.getElementById('link-sq-line').value;
+  const al     = document.getElementById('link-sq-alert');
+  if (!id)     { al.style.display='block'; al.className='alert alert-error'; al.textContent='Select a quote.'; return; }
+  if (!lineId) { al.style.display='block'; al.className='alert alert-error'; al.textContent='Select which quote line this quote is for.'; return; }
+  const { error } = await supabaseClient.from('supplier_quotes').update({ rfq_id: _rfqId, rfq_line_id: lineId }).eq('id', id);
   if (error) { al.style.display='block'; al.className='alert alert-error'; al.textContent='Failed: '+error.message; return; }
   closeLinkModal();
   renderCostsTab();

--- a/js/portal/sidebar.js
+++ b/js/portal/sidebar.js
@@ -19,7 +19,7 @@
 (function () {
 
   // Portal build version — keep in sync with DEVELOPMENT.md "Current Version".
-  const PORTAL_VERSION = 'v0.7.0';
+  const PORTAL_VERSION = 'v0.7.1';
 
   // ── Path depth ────────────────────────────────────────────────────────────
   // Work out how many directory levels the current page sits below portal/


### PR DESCRIPTION
## v0.7.1 — VAT-exempt quotes, currency/PDF fixes, and quote-line allocation

### Summary

- Added a per-RFQ **VAT-exempt toggle** on the Build Quote tab (VM isn't yet VAT registered, and some trades are 'string' chain trades that never touch the UK) — when off, the VAT column, VAT summary, and VAT total are omitted entirely from the customer-facing quote instead of showing 0%.
- **Sequential quote numbering** (`VM-Q-{year}-{4-digit}`, starting at 0050) replacing random reference generation.
- Fixed a **currency-mislabelling bug**: USD-quoted RFQs displayed a `£` symbol throughout the Build Quote tab and the customer document despite storing correct USD figures, including the Convert-to-Order flow (USD totals now convert back to GBP before pre-filling the trade's sell price).
- **Generated quote PDF fixes**: clean page-break behaviour (Terms/footer no longer split mid-paragraph across a page boundary), fixed the line-item table clipping off the right edge of the page (capture width now constrained to the printable A4 area), and accurate "Page X of Y" numbers stamped onto the output (replacing a hardcoded, always-wrong "Page 1 of 1").
- **Compressed the quote document layout** to help short quotes fit on a single page — removed a redundant "Estimate" heading, removed the self-evident "ADDRESS" label, tightened spacing throughout.
- Fixed **quantity display**: whole-number MT quantities no longer render with misleading trailing zeros (e.g. "12.000"), while genuine fractional tonnages still show up to 3dp. Applied to both the customer quote and internal RFQ Lines tab.
- **"Link Supplier Quote"** on the Cost Inputs tab now requires allocating the quote to an RFQ line (`rfq_line_id`), matching the "Add Supplier Quote" form — previously a linked quote was left unallocated.
- Dev log (`DEVELOPMENT.md`) updated to v0.7.1 and all previously-pending SQL migrations confirmed applied and marked as such.

### Migrations

All migrations referenced by this branch have been run against the database (confirmed by user), including `20260713_customer_quotes_vat_applicable.sql`.

### Test plan

- [ ] Create/open an RFQ, toggle VAT off, confirm the generated customer quote omits all VAT elements
- [ ] Generate a USD-currency quote and confirm `$` displays consistently (Build Quote tab, customer document, Convert-to-Order)
- [ ] Download a quote PDF and confirm it paginates cleanly, the table doesn't clip on the right, and the page-count footer is accurate
- [ ] Confirm whole-number MT quantities display without trailing zeros
- [ ] Link an existing supplier quote on the Cost Inputs tab and confirm it now allocates to a line
